### PR TITLE
Improve rejoin flow and drag-first gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Fresh React + Vite rewrite of the old repo.
 - 4-player lobby using Firebase Realtime Database
 - Host creates a 6-character room code
 - Players join by code with just a display name (no auth UI)
+- Every game now gets a shareable rejoin URL (`?game=ABC123`) and the current browser remembers the last active session
+- Existing seated players can reopen the saved URL on the same browser and resume mid-game instead of getting locked out by the lobby-only join flow
+- Drag-first card play: drag onto the table to trail, onto highlighted board cards to match, or onto capture lanes for addition captures
 - Host vets joined names and starts when 4 seats are filled
 - Teams are seat-based: seats 1 & 3 vs seats 2 & 4
 - Actual turn-based Cuarenta game flow with:
@@ -47,7 +50,7 @@ Rules source used: https://www.pagat.com/fishing/cuarenta.html
 ## Firebase notes
 This app expects the Firebase project `cuarenta-dfbf1`.
 
-Because the requested flow is "no auth for now", the current `database.rules.json` is intentionally permissive and should be treated as temporary/dev-only. Before production, tighten rules around game creation and writes.
+Because the requested flow is still "no auth UI for now", the database rules hardening here is structural rather than identity-perfect. The rules now validate room-code shape, required metadata, player counts, name lengths, score bounds, and session metadata so the database is less of a free-for-all, but a determined attacker could still impersonate writes without anonymous/custom auth.
 
 Expected RTDB path:
 - `games/<CODE>`
@@ -69,8 +72,7 @@ firebase deploy --only hosting,database
 If you deploy behind another web server instead of Firebase Hosting, serve the `dist/` folder at the path you built for. For `itsyasha.com/cuarenta`, build with `VITE_BASE_PATH=/cuarenta/` and keep SPA rewrites enabled.
 
 ## Current limitations / follow-up
-- No auth UI. Identity is just a local browser-generated player id plus chosen name.
+- No auth UI. Identity is still a local browser-generated player id plus chosen name, so true seat ownership still wants anonymous/custom auth later.
+- Rejoin is intentionally same-browser and same-local-player-id. It is robust for refresh/disconnect/reopen, not for arbitrary device handoff.
 - Ronda-caida 10-point remembered bonus is not implemented yet.
-- The UI is functional and clean, but not a polished final visual design from Stitch.
-- Database rules are intentionally broad for rapid testing and should be hardened before public launch.
- be hardened before public launch.
+- The UI is much more tactile now, but it is still a pragmatic drag-first web implementation, not full Hearthstone-grade animation/polish.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Rules source used: https://www.pagat.com/fishing/cuarenta.html
 ## Firebase notes
 This app expects the Firebase project `cuarenta-dfbf1`.
 
-Because the requested flow is still "no auth UI for now", the database rules hardening here is structural rather than identity-perfect. The rules now validate room-code shape, required metadata, player counts, name lengths, score bounds, and session metadata so the database is less of a free-for-all, but a determined attacker could still impersonate writes without anonymous/custom auth.
+Because the requested flow is still "no auth UI for now", the database rules here are intentionally light. In this PR they validate the room-code shape and ensure the stored `code` field matches the `games/<CODE>` path, but they do not yet enforce player counts, name lengths, score bounds, or session metadata, so a determined attacker could still impersonate writes without anonymous/custom auth.
 
 Expected RTDB path:
 - `games/<CODE>`

--- a/database.rules.json
+++ b/database.rules.json
@@ -3,7 +3,61 @@
     "games": {
       ".read": true,
       "$code": {
-        ".write": true
+        ".write": "newData.exists() && $code.matches(/^[A-HJ-NP-Z2-9]{6}$/) && newData.child('code').val() === $code",
+        ".validate": "newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && newData.child('lastActivityAt').isNumber() && newData.child('players').childrenCount() > 0 && newData.child('players').childrenCount() <= 4 && newData.child('seating').childrenCount() > 0 && newData.child('seating').childrenCount() <= 4 && newData.child('scores').hasChildren(['A', 'B']) && newData.child('players').hasChild(newData.child('hostId').val())",
+        "code": {
+          ".validate": "newData.isString() && newData.val() === $code"
+        },
+        "status": {
+          ".validate": "newData.isString() && (newData.val() === 'lobby' || newData.val() === 'playing' || newData.val() === 'finished')"
+        },
+        "hostId": {
+          ".validate": "newData.isString() && newData.val().matches(/^player_[a-z0-9-]{8,}$/)"
+        },
+        "createdAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "updatedAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "lastActivityAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "startedAt": {
+          ".validate": "!newData.exists() || newData.isNumber()"
+        },
+        "finishedAt": {
+          ".validate": "!newData.exists() || newData.isNumber()"
+        },
+        "winner": {
+          ".validate": "!newData.exists() || newData.val() === 'A' || newData.val() === 'B'"
+        },
+        "lobbyMessage": {
+          ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 120)"
+        },
+        "players": {
+          "$playerId": {
+            ".validate": "$playerId.matches(/^player_[a-z0-9-]{8,}$/) && newData.hasChildren(['id', 'name', 'joinedAt', 'isHost']) && newData.child('id').val() === $playerId && newData.child('name').isString() && newData.child('name').val().length > 0 && newData.child('name').val().length <= 24 && newData.child('joinedAt').isNumber() && newData.child('isHost').isBoolean() && (!newData.child('lastSeenAt').exists() || newData.child('lastSeenAt').isNumber()) && (!newData.child('rejoinedAt').exists() || newData.child('rejoinedAt').isNumber()) && (!newData.child('reconnectCount').exists() || newData.child('reconnectCount').isNumber())"
+          }
+        },
+        "seating": {
+          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          "$seat": {
+            ".validate": "newData.isString()"
+          }
+        },
+        "scores": {
+          ".validate": "newData.hasChildren(['A', 'B']) && newData.child('A').isNumber() && newData.child('B').isNumber() && newData.child('A').val() >= 0 && newData.child('B').val() >= 0 && newData.child('A').val() <= 40 && newData.child('B').val() <= 40"
+        },
+        "session": {
+          ".validate": "newData.hasChildren(['version', 'reconnectable', 'createdAt', 'updatedAt']) && newData.child('version').val() === 2 && newData.child('reconnectable').val() === true && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && (!newData.child('startedAt').exists() || newData.child('startedAt').isNumber()) && (!newData.child('finishedAt').exists() || newData.child('finishedAt').isNumber()) && (!newData.child('lastMoveAt').exists() || newData.child('lastMoveAt').isNumber()) && (!newData.child('lastAction').exists() || newData.child('lastAction').isString()) && (!newData.child('lastActorId').exists() || newData.child('lastActorId').isString())"
+        },
+        "round": {
+          ".validate": "!newData.exists() || newData.hasChildren(['handNumber', 'dealerIndex', 'turnOrder', 'turnPlayerId', 'activeDeal', 'playsInCurrentDeal', 'hands', 'board', 'capturePiles', 'capturedCardCount', 'perDealHands', 'events', 'teamsByPlayer', 'scores'])"
+        },
+        "$other": {
+          ".validate": true
+        }
       }
     }
   }

--- a/database.rules.json
+++ b/database.rules.json
@@ -3,58 +3,8 @@
     "games": {
       ".read": true,
       "$code": {
-        ".write": "newData.exists() && $code.matches(/^[A-HJ-NP-Z2-9]{6}$/) && newData.child('code').val() === $code",
-        ".validate": "newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && newData.child('lastActivityAt').isNumber() && newData.child('players').hasChild(newData.child('hostId').val()) && newData.child('seating/0').isString() && !newData.child('seating/4').exists() && newData.child('scores').hasChildren(['A', 'B'])",
-        "code": {
-          ".validate": "newData.isString() && newData.val() === $code"
-        },
-        "status": {
-          ".validate": "newData.isString() && (newData.val() === 'lobby' || newData.val() === 'playing' || newData.val() === 'finished')"
-        },
-        "hostId": {
-          ".validate": "newData.isString() && newData.val().matches(/^player_[a-z0-9-]{8,}$/)"
-        },
-        "createdAt": {
-          ".validate": "newData.isNumber()"
-        },
-        "updatedAt": {
-          ".validate": "newData.isNumber()"
-        },
-        "lastActivityAt": {
-          ".validate": "newData.isNumber()"
-        },
-        "startedAt": {
-          ".validate": "!newData.exists() || newData.isNumber()"
-        },
-        "finishedAt": {
-          ".validate": "!newData.exists() || newData.isNumber()"
-        },
-        "winner": {
-          ".validate": "!newData.exists() || newData.val() === 'A' || newData.val() === 'B'"
-        },
-        "lobbyMessage": {
-          ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 120)"
-        },
-        "players": {
-          "$playerId": {
-            ".validate": "$playerId.matches(/^player_[a-z0-9-]{8,}$/) && newData.hasChildren(['id', 'name', 'joinedAt', 'isHost']) && newData.child('id').val() === $playerId && newData.child('name').isString() && newData.child('name').val().length > 0 && newData.child('name').val().length <= 24 && newData.child('joinedAt').isNumber() && newData.child('isHost').isBoolean() && (!newData.child('lastSeenAt').exists() || newData.child('lastSeenAt').isNumber()) && (!newData.child('rejoinedAt').exists() || newData.child('rejoinedAt').isNumber()) && (!newData.child('reconnectCount').exists() || newData.child('reconnectCount').isNumber())"
-          }
-        },
-        "seating": {
-          ".validate": "newData.child('0').isString() && !newData.child('4').exists()",
-          "$seat": {
-            ".validate": "$seat.matches(/^[0-3]$/) && newData.isString()"
-          }
-        },
-        "scores": {
-          ".validate": "newData.hasChildren(['A', 'B']) && newData.child('A').isNumber() && newData.child('B').isNumber() && newData.child('A').val() >= 0 && newData.child('B').val() >= 0 && newData.child('A').val() <= 40 && newData.child('B').val() <= 40"
-        },
-        "session": {
-          ".validate": "newData.hasChildren(['version', 'reconnectable', 'createdAt', 'updatedAt']) && newData.child('version').val() === 2 && newData.child('reconnectable').val() === true && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && (!newData.child('startedAt').exists() || newData.child('startedAt').isNumber()) && (!newData.child('finishedAt').exists() || newData.child('finishedAt').isNumber()) && (!newData.child('lastMoveAt').exists() || newData.child('lastMoveAt').isNumber()) && (!newData.child('lastAction').exists() || newData.child('lastAction').isString()) && (!newData.child('lastActorId').exists() || newData.child('lastActorId').isString())"
-        },
-        "round": {
-          ".validate": "!newData.exists() || newData.hasChildren(['handNumber', 'dealerIndex', 'turnOrder', 'turnPlayerId', 'activeDeal', 'playsInCurrentDeal', 'hands', 'board', 'capturePiles', 'capturedCardCount', 'perDealHands', 'events', 'teamsByPlayer', 'scores'])"
-        },
+        ".write": "$code.matches(/^[A-HJ-NP-Z2-9]{6}$/)",
+        ".validate": "newData.exists() && newData.child('code').isString() && newData.child('code').val() === $code",
         "$other": {
           ".validate": true
         }

--- a/database.rules.json
+++ b/database.rules.json
@@ -4,7 +4,7 @@
       ".read": true,
       "$code": {
         ".write": "newData.exists() && $code.matches(/^[A-HJ-NP-Z2-9]{6}$/) && newData.child('code').val() === $code",
-        ".validate": "newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && newData.child('lastActivityAt').isNumber() && newData.child('players').childrenCount() > 0 && newData.child('players').childrenCount() <= 4 && newData.child('seating').childrenCount() > 0 && newData.child('seating').childrenCount() <= 4 && newData.child('scores').hasChildren(['A', 'B']) && newData.child('players').hasChild(newData.child('hostId').val())",
+        ".validate": "newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('createdAt').isNumber() && newData.child('updatedAt').isNumber() && newData.child('lastActivityAt').isNumber() && newData.child('players').hasChild(newData.child('hostId').val()) && newData.child('seating/0').isString() && !newData.child('seating/4').exists() && newData.child('scores').hasChildren(['A', 'B'])",
         "code": {
           ".validate": "newData.isString() && newData.val() === $code"
         },
@@ -41,9 +41,9 @@
           }
         },
         "seating": {
-          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          ".validate": "newData.child('0').isString() && !newData.child('4').exists()",
           "$seat": {
-            ".validate": "newData.isString()"
+            ".validate": "$seat.matches(/^[0-3]$/) && newData.isString()"
           }
         },
         "scores": {

--- a/database.rules.json
+++ b/database.rules.json
@@ -5,6 +5,9 @@
       "$code": {
         ".write": "$code.matches(/^[A-HJ-NP-Z2-9]{6}$/)",
         ".validate": "newData.exists() && newData.child('code').isString() && newData.child('code').val() === $code",
+        "code": {
+          ".validate": "newData.isString() && newData.val() === $code"
+        },
         "$other": {
           ".validate": true
         }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,11 @@ import { get, onValue, ref, runTransaction } from 'firebase/database';
 import { databaseUrl, db } from './lib/firebase';
 import { getLocalPlayerId, getSavedName, saveName } from './lib/localPlayer';
 import { applyMove, createInitialGameState, generateGameCode, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
+import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
+
+function moveKey(move) {
+  return `${move.type}:${move.playedCardId}:${(move.captureIds || []).join(',')}`;
+}
 
 function cardText(card) {
   return `${card.rank}${card.suit}`;
@@ -28,8 +33,24 @@ function cardSuitClass(card) {
   return card?.suit === '♥' || card?.suit === '♦' ? 'is-red' : 'is-dark';
 }
 
+function stampSessionMetadata(target, { now = Date.now(), action, actorId }) {
+  target.updatedAt = now;
+  target.lastActivityAt = now;
+  target.session = {
+    version: 2,
+    reconnectable: true,
+    createdAt: target.session?.createdAt || target.createdAt || now,
+    startedAt: target.session?.startedAt || target.startedAt || null,
+    finishedAt: target.session?.finishedAt || target.finishedAt || null,
+    updatedAt: now,
+    lastMoveAt: target.session?.lastMoveAt || null,
+    lastAction: action,
+    lastActorId: actorId,
+  };
+}
+
 function GameCode({ code }) {
-  return <div className="share-pill">Share code: <strong>{code}</strong></div>;
+  return <div className="share-pill">Game <strong>{code}</strong></div>;
 }
 
 function LobbySeat({ player, isCurrent, slot }) {
@@ -70,59 +91,132 @@ function TurnOrder({ game, currentPlayerId }) {
   );
 }
 
-function Board({ cards, deckRemaining, canLimpia }) {
+function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, directDropMoves, trailMove, dragCardId, onPlay }) {
   const safeCards = Array.isArray(cards) ? cards : [];
+  const highlighted = new Set(highlightedCaptureIds || []);
+  const trailArmed = Boolean(trailMove) && dragCardId === trailMove.playedCardId;
 
   return (
-    <section className="board-shell">
+    <section className={`board-shell ${trailArmed ? 'board-shell-armed' : ''}`}>
       <div className="board-hud">
         <div className="hud-chip">Deck: {deckRemaining}</div>
         <div className="hud-chip accent">{canLimpia ? 'Limpia live' : 'No limpia bonus'}</div>
       </div>
-      <div className="table-grid">
-        {safeCards.length ? safeCards.map((card) => (
-          <div key={card.id} className={`stitch-card board-card ${cardSuitClass(card)}`}>
-            <div className="card-corner">{card.rank}</div>
-            <div className="card-center">{card.suit}</div>
-            <div className="card-corner bottom">{card.rank}</div>
-          </div>
-        )) : <div className="empty-table">No cards on the table yet</div>}
+      <div
+        className={`table-grid ${trailArmed ? 'is-drop-target' : ''}`}
+        onDragOver={(event) => {
+          if (!trailArmed) return;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'move';
+        }}
+        onDrop={(event) => {
+          if (!trailArmed || !trailMove) return;
+          event.preventDefault();
+          onPlay(trailMove);
+        }}
+      >
+        {safeCards.length ? safeCards.map((card) => {
+          const directMove = directDropMoves?.[card.id];
+          const canDirectDrop = Boolean(directMove) && dragCardId === directMove.playedCardId;
+
+          return (
+            <div
+              key={card.id}
+              className={`stitch-card board-card ${cardSuitClass(card)} ${highlighted.has(card.id) ? 'is-highlighted' : ''} ${directMove ? 'is-click-target' : ''} ${canDirectDrop ? 'is-direct-target' : ''}`}
+              onClick={() => directMove && onPlay(directMove)}
+              onDragOver={(event) => {
+                if (!canDirectDrop) return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'move';
+              }}
+              onDrop={(event) => {
+                if (!canDirectDrop) return;
+                event.preventDefault();
+                event.stopPropagation();
+                onPlay(directMove);
+              }}
+            >
+              <div className="card-corner">{card.rank}</div>
+              <div className="card-center">{card.suit}</div>
+              <div className="card-corner bottom">{card.rank}</div>
+            </div>
+          );
+        }) : <div className="empty-table">No cards on the table yet</div>}
       </div>
     </section>
   );
 }
 
-function MovePicker({ hand, legalMoves, onPlay, isYourTurn }) {
-  const [selectedCardId, setSelectedCardId] = useState('');
-  const [selectedMoveKey, setSelectedMoveKey] = useState('');
+function MoveOptionCard({ move, boardCardsById, isPreviewed, dragCardId, onPreview, onPlay }) {
+  const captureCards = (move.captureIds || []).map((id) => boardCardsById[id]).filter(Boolean);
+  const canDrop = dragCardId === move.playedCardId;
+  const kindLabel = move.type === 'trail' ? 'Trail' : move.type === 'match' ? 'Match' : 'Add capture';
 
-  useEffect(() => {
-    if (!hand.some((card) => card.id === selectedCardId)) {
-      setSelectedCardId(hand[0]?.id || '');
-      setSelectedMoveKey('');
-    }
-  }, [hand, selectedCardId]);
+  return (
+    <button
+      type="button"
+      className={`move-option ${isPreviewed ? 'previewed' : ''} ${canDrop ? 'drop-ready' : ''}`}
+      onClick={() => onPlay(move)}
+      onMouseEnter={() => onPreview(moveKey(move))}
+      onMouseLeave={() => onPreview('')}
+      onFocus={() => onPreview(moveKey(move))}
+      onBlur={() => onPreview('')}
+      onDragOver={(event) => {
+        if (!canDrop) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      }}
+      onDrop={(event) => {
+        if (!canDrop) return;
+        event.preventDefault();
+        onPlay(move);
+      }}
+    >
+      <div className="move-option-head">
+        <span className="move-kind">{kindLabel}</span>
+        <span className="move-kicker">{move.type === 'trail' ? 'Drop on table' : `${captureCards.length} captured`}</span>
+      </div>
+      {captureCards.length ? (
+        <div className="move-capture-row">
+          {captureCards.map((card) => <span key={card.id} className={`mini-card ${cardSuitClass(card)}`}>{cardText(card)}</span>)}
+        </div>
+      ) : (
+        <div className="move-empty-target">Open table drop</div>
+      )}
+      <div className="move-label">{move.label}</div>
+    </button>
+  );
+}
 
-  const movesForCard = legalMoves.filter((move) => move.playedCardId === selectedCardId);
-  const selectedMove = movesForCard.find((move) => `${move.type}:${(move.captureIds || []).join(',')}` === selectedMoveKey) || movesForCard[0];
-
-  useEffect(() => {
-    if (movesForCard.length) {
-      setSelectedMoveKey(`${movesForCard[0].type}:${(movesForCard[0].captureIds || []).join(',')}`);
-    } else {
-      setSelectedMoveKey('');
-    }
-  }, [selectedCardId, legalMoves]);
+function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, selectedCardId, setSelectedCardId, dragCardId, setDragCardId, previewMoveKey, setPreviewMoveKey }) {
+  const activeCardId = dragCardId || selectedCardId || hand[0]?.id || '';
+  const movesForCard = legalMoves.filter((move) => move.playedCardId === activeCardId);
 
   return (
     <section className="hand-shell">
       <div className="hand-head">
         <span>Your hand</span>
-        <span className="hand-kicker">Cuarenta</span>
+        <span className="hand-kicker">Drag cards like a civilized person</span>
       </div>
       <div className="hand-row stitch-hand-row">
         {hand.map((card) => (
-          <button key={card.id} className={`stitch-card hand-card ${cardSuitClass(card)} ${selectedCardId === card.id ? 'selected' : ''}`} onClick={() => setSelectedCardId(card.id)}>
+          <button
+            key={card.id}
+            type="button"
+            draggable={isYourTurn}
+            className={`stitch-card hand-card ${cardSuitClass(card)} ${selectedCardId === card.id ? 'selected' : ''} ${dragCardId === card.id ? 'dragging' : ''}`}
+            onClick={() => setSelectedCardId(card.id)}
+            onDragStart={(event) => {
+              setSelectedCardId(card.id);
+              setDragCardId(card.id);
+              event.dataTransfer.effectAllowed = 'move';
+              event.dataTransfer.setData('text/plain', card.id);
+            }}
+            onDragEnd={() => {
+              setDragCardId('');
+              setPreviewMoveKey('');
+            }}
+          >
             <div className="card-corner">{card.rank}</div>
             <div className="card-center">{card.suit}</div>
             <div className="card-corner bottom">{card.rank}</div>
@@ -131,18 +225,20 @@ function MovePicker({ hand, legalMoves, onPlay, isYourTurn }) {
       </div>
       {isYourTurn ? (
         <div className="play-controls">
-          <label>
-            Available plays
-            <select value={selectedMoveKey} onChange={(event) => setSelectedMoveKey(event.target.value)}>
-              {movesForCard.map((move) => {
-                const key = `${move.type}:${(move.captureIds || []).join(',')}`;
-                return <option key={key} value={key}>{move.label}</option>;
-              })}
-            </select>
-          </label>
-          <button className="primary-button" disabled={!selectedMove} onClick={() => selectedMove && onPlay(selectedMove)}>
-            Play selected move
-          </button>
+          <div className="ghost-note">Drag onto the table to trail, onto a highlighted board card to match, or onto one of the capture lanes below.</div>
+          <div className="move-options-grid">
+            {movesForCard.map((move) => (
+              <MoveOptionCard
+                key={moveKey(move)}
+                move={move}
+                boardCardsById={boardCardsById}
+                isPreviewed={previewMoveKey === moveKey(move)}
+                dragCardId={dragCardId}
+                onPreview={setPreviewMoveKey}
+                onPlay={onPlay}
+              />
+            ))}
+          </div>
         </div>
       ) : <div className="muted-note">Waiting for your turn.</div>}
     </section>
@@ -188,16 +284,69 @@ function ActivityPanel({ round, game, currentPlayerId }) {
 }
 
 export default function App() {
+  const initialUrlCode = getGameCodeFromUrl();
+  const initialSavedSession = getSavedSession();
+
   const [name, setName] = useState(getSavedName());
-  const [joinCode, setJoinCode] = useState('');
-  const [gameCode, setGameCode] = useState('');
+  const [joinCode, setJoinCode] = useState(initialUrlCode || '');
+  const [gameCode, setGameCode] = useState(initialUrlCode || initialSavedSession?.gameCode || '');
+  const [savedSession, setSavedSession] = useState(initialSavedSession);
   const [game, setGame] = useState(null);
+  const [gameLoadState, setGameLoadState] = useState(gameCode ? 'loading' : 'idle');
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [dbStatus, setDbStatus] = useState('checking');
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [selectedCardId, setSelectedCardId] = useState('');
+  const [dragCardId, setDragCardId] = useState('');
+  const [previewMoveKey, setPreviewMoveKey] = useState('');
 
   const playerId = useMemo(() => getLocalPlayerId(), []);
   const gameRef = useMemo(() => (gameCode ? ref(db, `games/${gameCode}`) : null), [gameCode]);
+
+  function rememberSession(code) {
+    saveGameSession(code);
+    setSavedSession({ gameCode: code, lastVisitedAt: Date.now() });
+  }
+
+  function forgetSavedGame() {
+    clearSavedSession();
+    setSavedSession(null);
+    if (savedSession?.gameCode === gameCode) {
+      setGameCode('');
+      setGame(null);
+      setGameLoadState('idle');
+    }
+  }
+
+  function returnHome() {
+    setGameCode('');
+    setGame(null);
+    setGameLoadState('idle');
+    setError('');
+  }
+
+  async function copyShareLink() {
+    const shareUrl = buildGameUrl(gameCode);
+    if (!shareUrl) return;
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setLinkCopied(true);
+    } catch {
+      window.prompt('Copy this rejoin link:', shareUrl);
+    }
+  }
+
+  useEffect(() => {
+    if (!linkCopied) return undefined;
+    const timer = window.setTimeout(() => setLinkCopied(false), 1800);
+    return () => window.clearTimeout(timer);
+  }, [linkCopied]);
+
+  useEffect(() => {
+    syncGameUrl(gameCode);
+  }, [gameCode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -216,17 +365,77 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (!gameRef) return undefined;
+    if (!gameRef) {
+      setGame(null);
+      setGameLoadState('idle');
+      return undefined;
+    }
+
+    setGame(null);
+    setGameLoadState('loading');
+
     return onValue(
       gameRef,
       (snapshot) => {
+        if (!snapshot.exists()) {
+          setGame(null);
+          setGameLoadState('missing');
+          return;
+        }
+
         setGame(snapshot.val());
+        setGameLoadState('loaded');
       },
       (firebaseError) => {
         setError(firebaseError.message || 'Realtime sync failed.');
+        setGameLoadState('missing');
       }
     );
   }, [gameRef]);
+
+  useEffect(() => {
+    if (game?.players?.[playerId] && game.code && savedSession?.gameCode !== game.code) {
+      rememberSession(game.code);
+    }
+  }, [game?.code, game?.players?.[playerId], playerId, savedSession?.gameCode]);
+
+  const seating = game?.seating?.map((id) => game.players[id]);
+  const isParticipant = Boolean(game?.players?.[playerId]);
+  const teams = teamSummary(game);
+  const round = game?.round;
+  const boardCards = Array.isArray(round?.board) ? round.board : [];
+  const boardCardsById = useMemo(
+    () => Object.fromEntries(boardCards.map((card) => [card.id, card])),
+    [boardCards]
+  );
+  const visibleHand = round ? (getVisibleHand(round, playerId) || []) : [];
+  const legalMoves = round ? (getLegalMoves(round, playerId) || []) : [];
+  const isHost = game?.hostId === playerId;
+  const isYourTurn = round?.turnPlayerId === playerId;
+  const currentTeamId = round?.teamsByPlayer?.[playerId]?.teamId;
+  const canLimpia = round ? ((game?.scores?.[currentTeamId] || 0) < 38) : false;
+  const activeCardId = dragCardId || selectedCardId || visibleHand[0]?.id || '';
+  const movesForActiveCard = legalMoves.filter((move) => move.playedCardId === activeCardId);
+  const previewedMove = movesForActiveCard.find((move) => moveKey(move) === previewMoveKey) || null;
+  const trailMove = movesForActiveCard.find((move) => move.type === 'trail') || null;
+  const directDropMoves = useMemo(() => {
+    const entries = movesForActiveCard
+      .filter((move) => move.type === 'match' && move.targetIds?.length === 1)
+      .map((move) => [move.targetIds[0], move]);
+    return Object.fromEntries(entries);
+  }, [movesForActiveCard]);
+
+  useEffect(() => {
+    if (!visibleHand.some((card) => card.id === selectedCardId)) {
+      setSelectedCardId(visibleHand[0]?.id || '');
+    }
+  }, [visibleHand, selectedCardId]);
+
+  useEffect(() => {
+    if (!movesForActiveCard.some((move) => moveKey(move) === previewMoveKey)) {
+      setPreviewMoveKey('');
+    }
+  }, [movesForActiveCard, previewMoveKey]);
 
   async function createGame() {
     const trimmed = name.trim();
@@ -250,6 +459,8 @@ export default function App() {
         created = result.committed;
         if (!created) code = generateGameCode();
       }
+      rememberSession(code);
+      setJoinCode(code);
       setGameCode(code);
     } catch (transactionError) {
       setError(transactionError.message || 'Unable to create game. Check Firebase database rules and config.');
@@ -260,7 +471,7 @@ export default function App() {
 
   async function joinGame() {
     const trimmed = name.trim();
-    const code = joinCode.trim().toUpperCase();
+    const code = normalizeGameCode(gameCode || joinCode);
     if (!trimmed || !code) return setError('Enter your name and a game code.');
     if (dbStatus === 'read-denied') return setError('RTDB public reads are currently blocked, so joining cannot work yet. Update the live database rules first.');
     saveName(trimmed);
@@ -272,25 +483,54 @@ export default function App() {
       const existingSnapshot = await get(joinRef);
       const existing = existingSnapshot.val();
       if (!existing) throw new Error('Game not found.');
-      if (existing.status !== 'lobby') throw new Error('Game already started.');
-      if (!existing.players?.[playerId] && (existing.seating || []).length >= 4) throw new Error('Game is full.');
+
+      if (existing.players?.[playerId]) {
+        const result = await runTransaction(joinRef, (current) => {
+          if (!current?.players?.[playerId]) return current;
+          const now = Date.now();
+          current.players[playerId] = {
+            ...current.players[playerId],
+            name: trimmed,
+            lastSeenAt: now,
+            rejoinedAt: now,
+            reconnectCount: (current.players[playerId].reconnectCount || 0) + 1,
+          };
+          stampSessionMetadata(current, { now, action: 'player_rejoined', actorId: playerId });
+          return current;
+        }, { applyLocally: false });
+
+        if (!result?.snapshot?.exists()) throw new Error('Game not found.');
+        rememberSession(code);
+        setJoinCode(code);
+        setGameCode(code);
+        return;
+      }
+
+      if (existing.status !== 'lobby') throw new Error('Game already started. Reopen the original game link on the same browser to reconnect.');
+      if ((existing.seating || []).length >= 4) throw new Error('Game is full.');
 
       const result = await runTransaction(joinRef, (current) => {
         if (!current) return current;
         current.players ||= {};
         current.seating ||= [];
+        const now = Date.now();
         current.players[playerId] = {
           id: playerId,
           name: trimmed,
-          joinedAt: Date.now(),
+          joinedAt: now,
+          lastSeenAt: now,
+          reconnectCount: 0,
           isHost: current.hostId === playerId,
         };
         if (!current.seating.includes(playerId)) current.seating.push(playerId);
         current.lobbyMessage = current.seating.length === 4 ? 'Ready for host review' : 'Waiting for players';
+        stampSessionMetadata(current, { now, action: 'player_joined', actorId: playerId });
         return current;
       }, { applyLocally: false });
 
       if (!result?.snapshot?.exists()) throw new Error('Game not found.');
+      rememberSession(code);
+      setJoinCode(code);
       setGameCode(code);
     } catch (transactionError) {
       setError(transactionError.message || 'Unable to join game.');
@@ -313,7 +553,9 @@ export default function App() {
     setBusy(false);
   }
 
-  async function playMove(move) {
+  async function playChosenMove(move) {
+    setDragCardId('');
+    setPreviewMoveKey('');
     setBusy(true);
     setError('');
     await runTransaction(gameRef, (current) => {
@@ -323,15 +565,9 @@ export default function App() {
     setBusy(false);
   }
 
-  const seating = game?.seating?.map((id) => game.players[id]);
-  const teams = teamSummary(game);
-  const round = game?.round;
-  const boardCards = Array.isArray(round?.board) ? round.board : [];
-  const visibleHand = round ? (getVisibleHand(round, playerId) || []) : [];
-  const legalMoves = round ? (getLegalMoves(round, playerId) || []) : [];
-  const isHost = game?.hostId === playerId;
-  const isYourTurn = round?.turnPlayerId === playerId;
-  const canLimpia = round ? (game.scores[round.teamsByPlayer[playerId]?.teamId] || 0) < 38 : false;
+  const showHome = !gameCode || gameLoadState === 'missing';
+  const showGameChrome = Boolean(gameCode) && gameLoadState !== 'missing';
+  const shareUrl = showGameChrome ? buildGameUrl(gameCode) : '';
 
   return (
     <main className="cuarenta-app">
@@ -344,18 +580,24 @@ export default function App() {
           </nav>
         </div>
         <div className="topbar-actions">
-          {game?.code ? <GameCode code={game.code} /> : null}
-          <button className="header-button">Share Code</button>
+          {showGameChrome ? <button type="button" className="secondary-chip" onClick={returnHome}>Home</button> : null}
+          {showGameChrome ? <GameCode code={gameCode} /> : null}
+          {showGameChrome ? <button type="button" className="header-button" onClick={copyShareLink}>{linkCopied ? 'Link copied' : 'Share link'}</button> : null}
         </div>
       </header>
 
-      {!gameCode ? (
+      {showHome ? (
         <section className="lobby-shell invite-mode">
           <div className="invite-copy">
             <div className="eyebrow">Lobby Invitation</div>
             <h1>Host or Join a Match</h1>
-            <p>Classic four-player Cuarenta with a private code and a host-controlled lobby.</p>
+            <p>Classic four-player Cuarenta with reconnectable links, saved local sessions, and drag-first card play.</p>
           </div>
+          {gameLoadState === 'missing' && gameCode ? (
+            <section className="notice-card">
+              Game <strong>{gameCode}</strong> is not in the database anymore. If this was your last session, you can forget it below and start fresh.
+            </section>
+          ) : null}
           <section className="auth-card">
             <label>
               Your name
@@ -365,10 +607,23 @@ export default function App() {
               <button className="primary-button" disabled={busy || dbStatus === 'checking'} onClick={createGame}>Host game</button>
             </div>
             <div className="join-inline">
-              <input value={joinCode} onChange={(event) => setJoinCode(event.target.value)} placeholder="Enter code" maxLength={6} />
+              <input value={joinCode} onChange={(event) => setJoinCode(normalizeGameCode(event.target.value))} placeholder="Enter code" maxLength={6} />
               <button className="secondary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Join</button>
             </div>
+            <div className="ghost-note">When you join from a link, this browser remembers the session so a refresh does not nuke the match.</div>
           </section>
+          {savedSession ? (
+            <section className="resume-card">
+              <div>
+                <div className="resume-title">Resume saved session</div>
+                <div className="resume-copy">{savedSession.gameCode} is still pinned to this browser.</div>
+              </div>
+              <div className="resume-actions">
+                <button type="button" className="secondary-button" onClick={() => setGameCode(savedSession.gameCode)}>Resume</button>
+                <button type="button" className="text-button" onClick={forgetSavedGame}>Forget</button>
+              </div>
+            </section>
+          ) : null}
         </section>
       ) : null}
 
@@ -378,7 +633,7 @@ export default function App() {
         </section>
       ) : null}
 
-      {gameCode && !game ? <section className="notice-card">Loading game…</section> : null}
+      {gameCode && gameLoadState === 'loading' ? <section className="notice-card">Loading game…</section> : null}
 
       {game && game.status === 'lobby' ? (
         <section className="lobby-shell">
@@ -387,33 +642,79 @@ export default function App() {
             <h1>{game.code.split('').join('-')}</h1>
             <p>{game.lobbyMessage || 'Share this code with three friends to start a classic match of Cuarenta.'}</p>
           </div>
+          <section className="notice-card slim-note">
+            Rejoin URL: <strong>{shareUrl}</strong>
+          </section>
           <div className="lobby-grid">
             {[0, 1, 2, 3].map((index) => <LobbySeat key={index} slot={index + 1} player={seating?.[index]} isCurrent={seating?.[index]?.id === playerId} />)}
           </div>
-          <div className="lobby-actions">
-            {isHost ? <button className="primary-button wide" disabled={busy || (game.seating || []).length !== 4} onClick={startGame}>Start Game</button> : null}
-            <div className="lobby-footnote">Requires 4 players to begin</div>
-          </div>
+          {!isParticipant ? (
+            <section className="auth-card join-lobby-card">
+              <label>
+                Your name
+                <input value={name} onChange={(event) => setName(event.target.value)} maxLength={24} placeholder="Mateo V." />
+              </label>
+              <button className="primary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Take a seat</button>
+              <div className="ghost-note">Open this same link later on this browser and you will land back in the game instead of being locked out.</div>
+            </section>
+          ) : (
+            <div className="lobby-actions">
+              {isHost ? <button className="primary-button wide" disabled={busy || (game.seating || []).length !== 4} onClick={startGame}>Start Game</button> : null}
+              <div className="lobby-footnote">Requires 4 players to begin</div>
+            </div>
+          )}
         </section>
       ) : null}
 
-      {game && round ? (
-        <section className="game-layout">
-          <TurnOrder game={game} currentPlayerId={playerId} />
-          <section className="center-column">
-            <div className="team-stats-row">
-              {teams.map((team) => <TeamCard key={team.teamId} team={team} />)}
-              <div className="phase-card">
-                <div className="team-stat-title">Current round</div>
-                <div className="phase-name">Hand {round.handNumber} · Deal {round.activeDeal}</div>
-                <div className="phase-turn">Turn: {game.players[round.turnPlayerId]?.name}</div>
-              </div>
-            </div>
-            <Board cards={round.board} deckRemaining={round.deckRemaining} canLimpia={canLimpia} />
-            <MovePicker hand={visibleHand} legalMoves={legalMoves} onPlay={playMove} isYourTurn={isYourTurn} />
-            {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
+      {game && round && isParticipant ? (
+        <>
+          <section className="notice-card slim-note">
+            Refresh-safe session is active for <strong>{game.code}</strong>. Reopen the same link on this browser to reconnect mid-match.
           </section>
-          <ActivityPanel round={round} game={game} currentPlayerId={playerId} />
+          <section className="game-layout">
+            <TurnOrder game={game} currentPlayerId={playerId} />
+            <section className="center-column">
+              <div className="team-stats-row">
+                {teams.map((team) => <TeamCard key={team.teamId} team={team} />)}
+                <div className="phase-card">
+                  <div className="team-stat-title">Current round</div>
+                  <div className="phase-name">Hand {round.handNumber} · Deal {round.activeDeal}</div>
+                  <div className="phase-turn">Turn: {game.players[round.turnPlayerId]?.name}</div>
+                </div>
+              </div>
+              <Board
+                cards={round.board}
+                deckRemaining={round.deckRemaining}
+                canLimpia={canLimpia}
+                highlightedCaptureIds={previewedMove?.captureIds || []}
+                directDropMoves={directDropMoves}
+                trailMove={trailMove}
+                dragCardId={dragCardId}
+                onPlay={playChosenMove}
+              />
+              <MovePicker
+                hand={visibleHand}
+                legalMoves={legalMoves}
+                boardCardsById={boardCardsById}
+                onPlay={playChosenMove}
+                isYourTurn={isYourTurn}
+                selectedCardId={selectedCardId}
+                setSelectedCardId={setSelectedCardId}
+                dragCardId={dragCardId}
+                setDragCardId={setDragCardId}
+                previewMoveKey={previewMoveKey}
+                setPreviewMoveKey={setPreviewMoveKey}
+              />
+              {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
+            </section>
+            <ActivityPanel round={round} game={game} currentPlayerId={playerId} />
+          </section>
+        </>
+      ) : null}
+
+      {game && round && !isParticipant ? (
+        <section className="notice-card">
+          This game is already in progress. Mid-game entry is intentionally limited to the original browser session for that seat, so use the original rejoin link from the player who was already in the game.
         </section>
       ) : null}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { get, onValue, ref, runTransaction } from 'firebase/database';
 import { databaseUrl, db } from './lib/firebase';
 import { getLocalPlayerId, getSavedName, saveName } from './lib/localPlayer';
 import { applyMove, createInitialGameState, generateGameCode, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
-import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
+import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, isValidGameCode, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
 
 function moveKey(move) {
   return `${move.type}:${move.playedCardId}:${(move.captureIds || []).join(',')}`;
@@ -284,8 +284,15 @@ function ActivityPanel({ round, game, currentPlayerId }) {
 }
 
 export default function App() {
-  const initialUrlCode = getGameCodeFromUrl();
-  const initialSavedSession = getSavedSession();
+  const [{ initialUrlCode, initialSavedSession }] = useState(() => {
+    const urlCode = getGameCodeFromUrl();
+    const savedSession = getSavedSession();
+
+    return {
+      initialUrlCode: urlCode,
+      initialSavedSession: savedSession,
+    };
+  });
 
   const [name, setName] = useState(getSavedName());
   const [joinCode, setJoinCode] = useState(initialUrlCode || '');
@@ -472,7 +479,7 @@ export default function App() {
   async function joinGame() {
     const trimmed = name.trim();
     const code = normalizeGameCode(gameCode || joinCode);
-    if (!trimmed || !code) return setError('Enter your name and a game code.');
+    if (!trimmed || !isValidGameCode(code)) return setError('Enter your name and a valid 6-character game code.');
     if (dbStatus === 'read-denied') return setError('RTDB public reads are currently blocked, so joining cannot work yet. Update the live database rules first.');
     saveName(trimmed);
     setBusy(true);

--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -104,25 +104,58 @@ export function assignTeams(players) {
   }, {});
 }
 
-export function createInitialGameState(hostName, hostId) {
+function withSessionMeta(game, meta = {}) {
+  const now = meta.now ?? Date.now();
+  const previousSession = game.session || {};
+
   return {
+    ...game,
+    updatedAt: now,
+    lastActivityAt: now,
+    session: {
+      version: 2,
+      reconnectable: true,
+      createdAt: previousSession.createdAt || game.createdAt || now,
+      startedAt: meta.startedAt ?? previousSession.startedAt ?? game.startedAt ?? null,
+      finishedAt: meta.finishedAt ?? previousSession.finishedAt ?? game.finishedAt ?? null,
+      updatedAt: now,
+      lastMoveAt: meta.lastMoveAt ?? previousSession.lastMoveAt ?? null,
+      lastAction: meta.lastAction ?? previousSession.lastAction ?? null,
+      lastActorId: meta.lastActorId ?? previousSession.lastActorId ?? null,
+    },
+  };
+}
+
+export function createInitialGameState(hostName, hostId) {
+  const now = Date.now();
+
+  return withSessionMeta({
     code: '',
     status: 'lobby',
     hostId,
-    createdAt: Date.now(),
+    createdAt: now,
+    updatedAt: now,
+    lastActivityAt: now,
     startedAt: null,
+    finishedAt: null,
     players: {
       [hostId]: {
         id: hostId,
         name: hostName.trim(),
-        joinedAt: Date.now(),
+        joinedAt: now,
+        lastSeenAt: now,
+        reconnectCount: 0,
         isHost: true,
       },
     },
     seating: [hostId],
     scores: { A: 0, B: 0 },
     lobbyMessage: 'Waiting for players',
-  };
+  }, {
+    now,
+    lastAction: 'lobby_created',
+    lastActorId: hostId,
+  });
 }
 
 function buildRound(players, dealerIndex, scores, handNumber = 1) {
@@ -197,16 +230,26 @@ function applyDealAnnouncements(round, dealNumber, players) {
 export function startMatchFromLobby(game) {
   const players = game.seating.map((playerId) => game.players[playerId]);
   const round = buildRound(players, 0, { A: 0, B: 0 }, 1);
-  return {
+  const now = Date.now();
+  const nextGame = {
     ...game,
     status: round.status === 'finished' ? 'finished' : 'playing',
-    startedAt: Date.now(),
+    startedAt: now,
+    finishedAt: round.status === 'finished' ? now : null,
     seating: players.map((player) => player.id),
     scores: round.scores,
     round,
     lobbyMessage: 'Game started',
     winner: round.winner || null,
   };
+
+  return withSessionMeta(nextGame, {
+    now,
+    startedAt: now,
+    finishedAt: round.status === 'finished' ? now : null,
+    lastAction: 'game_started',
+    lastActorId: game.hostId,
+  });
 }
 
 function visibleHandForPlayer(round, playerId) {
@@ -272,13 +315,14 @@ function summarizeCard(card) {
   return `${card.rank}${card.suit}`;
 }
 
-function finalizeHand(game) {
+function finalizeHand(game, lastActorId) {
   const round = game.round;
   const pointsByCards = { A: 0, B: 0 };
   const a = round.capturedCardCount.A;
   const b = round.capturedCardCount.B;
   const dealerTeam = round.teamsByPlayer[round.turnOrder[round.dealerIndex]]?.teamId || 'A';
   const nonDealerTeam = dealerTeam === 'A' ? 'B' : 'A';
+  const now = Date.now();
 
   if (a >= 20 || b >= 20) {
     if (a === 20 && b === 20) {
@@ -299,30 +343,42 @@ function finalizeHand(game) {
   round.events.unshift(`Hand ${round.handNumber} scored: Team A +${pointsByCards.A}, Team B +${pointsByCards.B}.`);
 
   if (nextScores.A >= 40 || nextScores.B >= 40) {
-    return {
+    return withSessionMeta({
       ...game,
       status: 'finished',
       scores: nextScores,
+      finishedAt: now,
       winner: nextScores.A >= 40 ? 'A' : 'B',
       round: { ...round, status: 'finished', scores: nextScores },
-    };
+    }, {
+      now,
+      finishedAt: now,
+      lastAction: 'game_finished',
+      lastActorId,
+    });
   }
 
   const players = game.seating.map((playerId) => game.players[playerId]);
   const nextDealerIndex = (round.dealerIndex + 1) % players.length;
   const nextRound = buildRound(players, nextDealerIndex, nextScores, round.handNumber + 1);
 
-  return {
+  return withSessionMeta({
     ...game,
     status: nextRound.status === 'finished' ? 'finished' : 'playing',
     scores: nextRound.scores,
     winner: nextRound.winner || null,
     round: nextRound,
-  };
+  }, {
+    now,
+    finishedAt: nextRound.status === 'finished' ? now : null,
+    lastAction: 'hand_scored',
+    lastActorId,
+  });
 }
 
 export function applyMove(game, playerId, move) {
   if (!game?.round || game.status !== 'playing') throw new Error('Game is not active.');
+  const now = Date.now();
   const round = structuredClone(game.round);
   round.board = Array.isArray(round.board) ? round.board : [];
   round.capturePiles = {
@@ -392,18 +448,34 @@ export function applyMove(game, playerId, move) {
     const players = game.seating.map((id) => game.players[id]);
     applyDealAnnouncements(round, 2, players);
     if (round.status === 'finished') {
-      return { ...game, status: 'finished', scores: round.scores, winner: round.winner, round };
+      return withSessionMeta({ ...game, status: 'finished', scores: round.scores, finishedAt: now, winner: round.winner, round }, {
+        now,
+        finishedAt: now,
+        lastAction: 'deal_started_and_finished',
+        lastActorId: playerId,
+        lastMoveAt: now,
+      });
     }
     round.events.unshift('Deal 2 has started.');
-    return { ...game, scores: round.scores, round };
+    return withSessionMeta({ ...game, scores: round.scores, round }, {
+      now,
+      lastAction: 'deal_started',
+      lastActorId: playerId,
+      lastMoveAt: now,
+    });
   }
 
   if (dealFinished && round.activeDeal === 2) {
-    return finalizeHand({ ...game, scores: round.scores, round });
+    return finalizeHand({ ...game, scores: round.scores, round }, playerId);
   }
 
   round.turnPlayerId = nextTurnPlayer(round);
-  return { ...game, scores: round.scores, round };
+  return withSessionMeta({ ...game, scores: round.scores, round }, {
+    now,
+    lastAction: selected.type === 'trail' ? 'card_trailed' : 'card_captured',
+    lastActorId: playerId,
+    lastMoveAt: now,
+  });
 }
 
 export function teamSummary(game) {

--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -1,7 +1,12 @@
 const ACTIVE_SESSION_KEY = 'cuarenta-active-session';
+const GAME_CODE_REGEX = /^[A-HJ-NP-Z2-9]{6}$/;
 
 export function normalizeGameCode(value = '') {
-  return String(value).toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+  return (String(value).toUpperCase().match(/[A-HJ-NP-Z2-9]/g) || []).join('').slice(0, 6);
+}
+
+export function isValidGameCode(value = '') {
+  return GAME_CODE_REGEX.test(String(value));
 }
 
 export function getSavedSession() {
@@ -12,7 +17,7 @@ export function getSavedSession() {
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     const gameCode = normalizeGameCode(parsed?.gameCode || '');
-    if (!gameCode) return null;
+    if (!isValidGameCode(gameCode)) return null;
     return {
       gameCode,
       lastVisitedAt: Number(parsed?.lastVisitedAt) || null,
@@ -25,20 +30,29 @@ export function getSavedSession() {
 export function saveGameSession(gameCode) {
   if (typeof window === 'undefined') return;
   const code = normalizeGameCode(gameCode);
-  if (!code) {
+  if (!isValidGameCode(code)) {
     clearSavedSession();
     return;
   }
 
-  window.localStorage.setItem(ACTIVE_SESSION_KEY, JSON.stringify({
-    gameCode: code,
-    lastVisitedAt: Date.now(),
-  }));
+  try {
+    window.localStorage.setItem(ACTIVE_SESSION_KEY, JSON.stringify({
+      gameCode: code,
+      lastVisitedAt: Date.now(),
+    }));
+  } catch {
+    // Ignore storage write failures so session persistence does not crash the app.
+  }
 }
 
 export function clearSavedSession() {
   if (typeof window === 'undefined') return;
-  window.localStorage.removeItem(ACTIVE_SESSION_KEY);
+
+  try {
+    window.localStorage.removeItem(ACTIVE_SESSION_KEY);
+  } catch {
+    // Ignore storage removal failures so session clearing does not crash the app.
+  }
 }
 
 export function getGameCodeFromUrl() {
@@ -46,19 +60,19 @@ export function getGameCodeFromUrl() {
 
   const url = new URL(window.location.href);
   const fromQuery = normalizeGameCode(url.searchParams.get('game') || '');
-  if (fromQuery) return fromQuery;
+  if (isValidGameCode(fromQuery)) return fromQuery;
 
   const parts = url.pathname.split('/').filter(Boolean);
   for (let index = 0; index < parts.length - 1; index += 1) {
     const segment = parts[index].toLowerCase();
     if (segment === 'g' || segment === 'game' || segment === 'join') {
       const fromPath = normalizeGameCode(parts[index + 1]);
-      if (fromPath) return fromPath;
+      if (isValidGameCode(fromPath)) return fromPath;
     }
   }
 
   const tail = normalizeGameCode(parts.at(-1) || '');
-  if (tail && /^[A-HJ-NP-Z2-9]{6}$/.test(tail)) return tail;
+  if (isValidGameCode(tail)) return tail;
 
   return '';
 }
@@ -69,7 +83,7 @@ export function syncGameUrl(gameCode) {
   const url = new URL(window.location.href);
   const code = normalizeGameCode(gameCode);
 
-  if (code) {
+  if (isValidGameCode(code)) {
     url.searchParams.set('game', code);
   } else {
     url.searchParams.delete('game');
@@ -84,7 +98,7 @@ export function buildGameUrl(gameCode) {
   const url = new URL(window.location.href);
   const code = normalizeGameCode(gameCode);
 
-  if (code) {
+  if (isValidGameCode(code)) {
     url.searchParams.set('game', code);
   } else {
     url.searchParams.delete('game');

--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -1,0 +1,94 @@
+const ACTIVE_SESSION_KEY = 'cuarenta-active-session';
+
+export function normalizeGameCode(value = '') {
+  return String(value).toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+}
+
+export function getSavedSession() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = window.localStorage.getItem(ACTIVE_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const gameCode = normalizeGameCode(parsed?.gameCode || '');
+    if (!gameCode) return null;
+    return {
+      gameCode,
+      lastVisitedAt: Number(parsed?.lastVisitedAt) || null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveGameSession(gameCode) {
+  if (typeof window === 'undefined') return;
+  const code = normalizeGameCode(gameCode);
+  if (!code) {
+    clearSavedSession();
+    return;
+  }
+
+  window.localStorage.setItem(ACTIVE_SESSION_KEY, JSON.stringify({
+    gameCode: code,
+    lastVisitedAt: Date.now(),
+  }));
+}
+
+export function clearSavedSession() {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(ACTIVE_SESSION_KEY);
+}
+
+export function getGameCodeFromUrl() {
+  if (typeof window === 'undefined') return '';
+
+  const url = new URL(window.location.href);
+  const fromQuery = normalizeGameCode(url.searchParams.get('game') || '');
+  if (fromQuery) return fromQuery;
+
+  const parts = url.pathname.split('/').filter(Boolean);
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const segment = parts[index].toLowerCase();
+    if (segment === 'g' || segment === 'game' || segment === 'join') {
+      const fromPath = normalizeGameCode(parts[index + 1]);
+      if (fromPath) return fromPath;
+    }
+  }
+
+  const tail = normalizeGameCode(parts.at(-1) || '');
+  if (tail && /^[A-HJ-NP-Z2-9]{6}$/.test(tail)) return tail;
+
+  return '';
+}
+
+export function syncGameUrl(gameCode) {
+  if (typeof window === 'undefined') return;
+
+  const url = new URL(window.location.href);
+  const code = normalizeGameCode(gameCode);
+
+  if (code) {
+    url.searchParams.set('game', code);
+  } else {
+    url.searchParams.delete('game');
+  }
+
+  window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
+export function buildGameUrl(gameCode) {
+  if (typeof window === 'undefined') return '';
+
+  const url = new URL(window.location.href);
+  const code = normalizeGameCode(gameCode);
+
+  if (code) {
+    url.searchParams.set('game', code);
+  } else {
+    url.searchParams.delete('game');
+  }
+
+  return url.toString();
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -59,13 +59,13 @@ button { cursor: pointer; }
 .topnav { display: flex; gap: 18px; color: var(--muted); }
 .topnav span:first-child { color: var(--primary-dark); text-decoration: underline; text-underline-offset: 6px; }
 .topbar-actions { display: flex; align-items: center; gap: 10px; }
-.header-button, .share-pill, .notice-card, .auth-card, .sidebar-panel, .board-shell, .profile-card, .activity-card, .team-stat, .phase-card, .hand-shell, .lobby-seat {
+.header-button, .share-pill, .notice-card, .auth-card, .sidebar-panel, .board-shell, .profile-card, .activity-card, .team-stat, .phase-card, .hand-shell, .lobby-seat, .resume-card {
   background: var(--surface-low);
   backdrop-filter: blur(10px);
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
 }
-.header-button, .share-pill {
+.header-button, .share-pill, .secondary-chip {
   border-radius: 12px;
   padding: 10px 14px;
   font-size: 13px;
@@ -74,6 +74,11 @@ button { cursor: pointer; }
   background: var(--primary);
   color: white;
   border: none;
+}
+.secondary-chip {
+  background: rgba(164, 93, 65, 0.10);
+  color: var(--primary-dark);
+  border: 1px solid rgba(134, 69, 43, 0.14);
 }
 .share-pill strong { color: var(--primary-dark); }
 
@@ -184,6 +189,12 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   padding: 16px 18px;
   border-radius: 18px;
   color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.slim-note {
+  margin-top: 0;
+  font-size: 13px;
 }
 
 .game-layout {
@@ -260,6 +271,11 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   background: rgba(164, 93, 65, 0.05);
   border: 2px solid rgba(164, 93, 65, 0.10);
   box-shadow: inset 0 0 40px rgba(164, 93, 65, 0.05);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+.board-shell-armed {
+  border-color: rgba(164, 93, 65, 0.28);
+  box-shadow: inset 0 0 0 2px rgba(164, 93, 65, 0.12), inset 0 0 40px rgba(164, 93, 65, 0.08);
 }
 .board-hud {
   position: absolute;
@@ -287,6 +303,12 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   gap: 16px;
   align-items: center;
   justify-items: center;
+  border-radius: 28px;
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+.table-grid.is-drop-target {
+  background: rgba(164, 93, 65, 0.08);
+  box-shadow: inset 0 0 0 2px rgba(164, 93, 65, 0.18);
 }
 .empty-table { color: var(--muted); }
 .stitch-card {
@@ -301,6 +323,7 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   justify-content: space-between;
   align-items: stretch;
   padding: 10px;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease, background 140ms ease;
 }
 .stitch-card.is-red { color: var(--primary); }
 .stitch-card.is-dark { color: #23201d; }
@@ -328,7 +351,81 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   gap: 12px;
 }
 .hand-card.selected { outline: 2px solid rgba(164, 93, 65, 0.35); transform: translateY(-4px); }
-.play-controls { margin-top: 16px; }
+.hand-card.dragging { transform: translateY(-10px) rotate(-2deg); box-shadow: 0 18px 30px rgba(80, 50, 40, 0.16); }
+.board-card.is-click-target { cursor: pointer; }
+.board-card.is-highlighted { transform: translateY(-6px); box-shadow: 0 18px 30px rgba(80, 50, 40, 0.16); border-color: rgba(164, 93, 65, 0.38); }
+.board-card.is-direct-target { box-shadow: 0 0 0 3px rgba(164, 93, 65, 0.18), 0 18px 30px rgba(80, 50, 40, 0.16); }
+.play-controls { margin-top: 16px; display: grid; gap: 14px; }
+.move-options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
+}
+.move-option {
+  text-align: left;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(134, 69, 43, 0.14);
+  background: rgba(255,255,255,0.78);
+  display: grid;
+  gap: 10px;
+}
+.move-option.previewed,
+.move-option.drop-ready {
+  border-color: rgba(164, 93, 65, 0.32);
+  box-shadow: 0 14px 24px rgba(80, 50, 40, 0.12);
+  transform: translateY(-2px);
+}
+.move-option-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+.move-kind {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 800;
+  color: var(--primary);
+}
+.move-kicker {
+  font-size: 12px;
+  color: var(--muted);
+}
+.move-capture-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.mini-card {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(245, 238, 228, 0.95);
+  border: 1px solid rgba(134, 69, 43, 0.12);
+  font-weight: 800;
+}
+.move-empty-target {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(164, 93, 65, 0.08);
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+.move-label {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+.ghost-note {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
 .muted-note { margin-top: 12px; color: var(--muted); }
 
 .activity-column { display: grid; gap: 16px; }
@@ -369,6 +466,37 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 .activity-title { font-family: 'Noto Serif', serif; color: var(--primary); font-weight: 700; margin-bottom: 12px; }
 .activity-card ul { margin: 0; padding-left: 18px; color: var(--muted); display: grid; gap: 10px; }
 
+.resume-card {
+  max-width: 520px;
+  margin: 0 auto;
+  border-radius: 22px;
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.resume-title {
+  font-weight: 800;
+  color: var(--primary-dark);
+}
+.resume-copy {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.resume-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.text-button {
+  background: transparent;
+  border: none;
+  color: var(--primary-dark);
+  font-weight: 800;
+}
+
 .error-banner {
   position: fixed;
   bottom: 14px;
@@ -394,7 +522,15 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   .topbar-actions { gap: 8px; }
   .share-pill { display: none; }
   .cuarenta-app { padding: 80px 12px 20px; }
-  .lobby-grid, .team-stats-row, .activity-column, .join-inline { grid-template-columns: 1fr; }
+  .lobby-grid, .team-stats-row, .activity-column, .join-inline, .resume-card { grid-template-columns: 1fr; }
   .invite-copy h1 { font-size: 46px; }
   .board-shell { padding: 72px 14px 18px; min-height: 320px; }
+  .resume-card {
+    display: grid;
+    justify-items: start;
+  }
+  .resume-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
## Summary
- add shareable game URLs and local saved-session resume so players can reconnect on the same browser
- add session metadata and player reconnect tracking to make in-progress games less fragile
- replace the dropdown-heavy move flow with drag-first interactions plus click fallbacks
- relax the live RTDB rules enough to unblock real multiplayer testing while keeping minimal code-shape guardrails

## What changed
- `src/lib/session.js`
  - parse/persist `?game=CODE`
  - remember active session locally
  - generate/copy shareable rejoin links
- `src/App.jsx`
  - restore sessions from URL/local storage
  - allow same-player rejoin after game start
  - add drag-first move interactions and move previewing
  - improve lobby/home flow around resume and share links
- `src/lib/gameLogic.js`
  - add session/update metadata to game state
  - track reconnect-related timing/action fields
- `database.rules.json`
  - simplify RTDB rules to a deployable, gameplay-unblocking version
- `README.md`
  - document reconnect and drag-first behavior

## Validation
- `npm run build`
- live deploy tested to `https://cuarenta-dfbf1.web.app/`
- manual early smoke test from Maxim:
  - rejoin flow worked
  - initial dragging behavior felt solid

## Notes
- current reconnect model is intentionally same-browser / same-local-player-id, not full cross-device seat reclaim
- RTDB rules were relaxed after stricter validation blocked actual gameplay starts during live testing
