### PR TITLE
Make Cuarenta much nicer to play

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
-VITE_FIREBASE_API_KEY=AIzaSyAnvPUD8NmYUC-fA7ypMvlrfIdAngL0KF0
-VITE_FIREBASE_AUTH_DOMAIN=cuarenta-dfbf1.firebaseapp.com
-VITE_FIREBASE_DATABASE_URL=https://cuarenta-dfbf1-default-rtdb.firebaseio.com
-VITE_FIREBASE_PROJECT_ID=cuarenta-dfbf1
-VITE_FIREBASE_STORAGE_BUCKET=cuarenta-dfbf1.firebasestorage.app
-VITE_FIREBASE_MESSAGING_SENDER_ID=78708075147
-VITE_FIREBASE_APP_ID=1:78708075147:web:3bffd7a9a76f0ed27fc28e
-VITE_FIREBASE_MEASUREMENT_ID=G-QE2JKLQ686
+# Copy to .env.local (or .env) before running locally.
+#
+# Safe default for contributors: use the Firebase Realtime Database emulator.
+# Start it separately with the Firebase CLI, then run the app.
+VITE_USE_FIREBASE_EMULATOR=true
+VITE_FIREBASE_EMULATOR_HOST=127.0.0.1
+VITE_FIREBASE_EMULATOR_PORT=9000
+VITE_FIREBASE_PROJECT_ID=cuarenta-local
+
+# If you intentionally want to point at a real Firebase project instead,
+# flip VITE_USE_FIREBASE_EMULATOR=false and fill every VITE_FIREBASE_* value below.
+VITE_FIREBASE_API_KEY=replace-with-your-web-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com
+VITE_FIREBASE_DATABASE_URL=https://your-project-id-default-rtdb.firebaseio.com
+VITE_FIREBASE_STORAGE_BUCKET=your-project-id.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=123456789012
+VITE_FIREBASE_APP_ID=1:123456789012:web:replace-with-your-app-id
+VITE_FIREBASE_MEASUREMENT_ID=G-OPTIONALMEASURE
 VITE_BASE_PATH=/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Fresh React + Vite rewrite of the old repo.
 - Players join by code with just a display name (no auth UI)
 - Every game now gets a shareable rejoin URL (`?game=ABC123`) and the current browser remembers the last active session
 - Existing seated players can reopen the saved URL on the same browser and resume mid-game instead of getting locked out by the lobby-only join flow
-- Drag-first card play: drag onto the table to trail, onto highlighted board cards to match, or onto capture lanes for addition captures
+- Drag-first card play: drag onto the table to trail, onto highlighted board cards to match, or onto capture lanes / live targets for addition captures
+- Stronger move previews: the table now shows capture order, caída targets, scoring swing badges, and clearer turn-state feedback before you commit
+- In-app rules + scoring reference drawer for the high-value Cuarenta edge cases
 - Host vets joined names and starts when 4 seats are filled
+- Opening dealer is chosen randomly among the seated players for a fairer start
 - Teams are seat-based: seats 1 & 3 vs seats 2 & 4
 - Actual turn-based Cuarenta game flow with:
   - matching captures
@@ -44,6 +47,10 @@ Rules source used: https://www.pagat.com/fishing/cuarenta.html
    ```bash
    npm run build
    ```
+5. Focused rules checks:
+   ```bash
+   npm test
+   ```
 
 `.env` is optional here because the Firebase web config already falls back to the known project values. If you want overrides, copy `.env.example` to `.env`.
 
@@ -75,4 +82,5 @@ If you deploy behind another web server instead of Firebase Hosting, serve the `
 - No auth UI. Identity is still a local browser-generated player id plus chosen name, so true seat ownership still wants anonymous/custom auth later.
 - Rejoin is intentionally same-browser and same-local-player-id. It is robust for refresh/disconnect/reopen, not for arbitrary device handoff.
 - Ronda-caida 10-point remembered bonus is not implemented yet.
+- The app auto-previews and auto-takes the full visible sequence for any chosen capture, so the real-world “missed sequence can be stolen by opponents” memory test is intentionally removed from the UI flow.
 - The UI is much more tactile now, but it is still a pragmatic drag-first web implementation, not full Hearthstone-grade animation/polish.

--- a/README.md
+++ b/README.md
@@ -2,29 +2,19 @@
 
 Fresh React + Vite rewrite of the old repo.
 
-## What is implemented
+## What this build already does
 - 4-player lobby using Firebase Realtime Database
 - Host creates a 6-character room code
-- Players join by code with just a display name (no auth UI)
-- Every game now gets a shareable rejoin URL (`?game=ABC123`) and the current browser remembers the last active session
+- Players join by code with just a display name (no auth UI yet)
+- Every game gets a shareable rejoin URL (`?game=ABC123`) and the current browser remembers the last active session
 - Existing seated players can reopen the saved URL on the same browser and resume mid-game instead of getting locked out by the lobby-only join flow
 - Drag-first card play: drag onto the table to trail, onto highlighted board cards to match, or onto capture lanes / live targets for addition captures
-- Stronger move previews: hoverable board targets now carry distinct match/addition semantics, the table groups exact target vs sequence cards, and the UI shows capture order, caída targets, and scoring swing badges before you commit
+- Stronger move previews: hoverable board targets carry match/addition semantics, the table groups exact target vs sequence cards, and the UI shows capture order, caída targets, and scoring swing badges before you commit
 - In-app rules + scoring reference drawer for the high-value Cuarenta edge cases
 - Host vets joined names and starts when 4 seats are filled
 - Opening dealer is chosen randomly among the seated players for a fairer start
 - Teams are seat-based: seats 1 & 3 vs seats 2 & 4
-- Actual turn-based Cuarenta game flow with:
-  - matching captures
-  - addition captures for A-7
-  - automatic upward sequence capture
-  - caida scoring (+2)
-  - limpia scoring (+2, except at 38+)
-  - ronda handling (+4 if team under 30)
-  - four-of-a-kind instant win on a deal
-  - 2 deals of 5 cards per player per hand
-  - end-of-hand card-count scoring
-  - repeated hands until a team reaches 40
+- Actual turn-based Cuarenta game flow with matching captures, A-7 addition captures, automatic upward sequence capture, caída, limpia, ronda handling, two deals of five cards, end-of-hand card-count scoring, and repeated hands until a team reaches 40
 
 Rules source used: https://www.pagat.com/fishing/cuarenta.html
 
@@ -34,53 +24,92 @@ Rules source used: https://www.pagat.com/fishing/cuarenta.html
 - Firebase Realtime Database
 
 ## Local setup
-1. Install deps:
-   ```bash
-   npm install
-   ```
-2. Run dev server:
-   ```bash
-   npm run dev
-   ```
-3. Open the local URL Vite prints (usually `http://localhost:5173/`).
-4. Build:
-   ```bash
-   npm run build
-   ```
-5. Focused rules checks:
-   ```bash
-   npm test
-   ```
+```bash
+npm install
+cp .env.example .env.local
+npm run dev
+```
 
-`.env` is optional here because the Firebase web config already falls back to the known project values. If you want overrides, copy `.env.example` to `.env`.
+Open the local URL Vite prints (usually `http://localhost:5173/`).
 
-## Firebase notes
-This app expects the Firebase project `cuarenta-dfbf1`.
+### Safe default: use the RTDB emulator
+The committed `.env.example` now defaults to the Firebase Realtime Database emulator instead of a real shared project.
 
-Because the requested flow is still "no auth UI for now", the database rules here are intentionally light. In this PR they validate the room-code shape and ensure the stored `code` field matches the `games/<CODE>` path, but they do not yet enforce player counts, name lengths, score bounds, or session metadata, so a determined attacker could still impersonate writes without anonymous/custom auth.
+Typical flow:
+```bash
+cp .env.example .env.local
+# leave VITE_USE_FIREBASE_EMULATOR=true
+firebase emulators:start --only database
+npm run dev
+```
 
-Expected RTDB path:
+### If you intentionally want a real Firebase project
+Set `VITE_USE_FIREBASE_EMULATOR=false` and fill every `VITE_FIREBASE_*` variable in `.env.local`.
+
+The app no longer bakes the current live Firebase web config into source code. If you do not provide config, the UI renders a clear setup notice instead of silently talking to a real backend.
+
+## Tests / build
+```bash
+npm test
+npm run build
+```
+
+## Firebase / public-surface notes
+This repo is **closer** to OSS-safe than before, but it is **not fully public-safe yet**.
+
+What changed in this pass:
+- the app no longer defaults local dev builds to the real live Firebase project
+- `.env.example` points contributors toward the emulator first
+- `database.rules.json` now enforces a tighter public shape: valid room code, 1-4 players, 1-4 seats, bounded player names, bounded scores, and bounded session metadata instead of allowing nearly-arbitrary payloads
+- README setup/deploy guidance now makes the backend choice explicit
+
+What is still intentionally rough:
+- there is still no auth UI, so the game path still relies on public reads/writes to function
+- shape validation is better, but it is not a substitute for anonymous/custom auth
+- a determined attacker can still write valid-looking game traffic and churn rooms
+- there is no quota / abuse-control story in-repo yet (alerts, App Check, rate limiting via server-side mediation, cleanup jobs, etc.)
+
+### Realtime Database path
 - `games/<CODE>`
 
 ## Hosting / deployment
-The Vite base path defaults to `/cuarenta/`, matching the intended deployment under `itsyasha.com/cuarenta`.
+Production builds should be explicit about which backend they target.
 
-Files included for Firebase Hosting:
-- `firebase.json`
-- `database.rules.json`
-
-Typical deploy flow once Firebase CLI is installed and authenticated:
+### Build for a hosted path
+For `itsyasha.com/cuarenta`, build with:
 ```bash
-npm install
+VITE_BASE_PATH=/cuarenta/ npm run build
+```
+
+### Build against a real Firebase project
+Do this only on purpose, with env vars present in the same shell:
+```bash
+set -a
+source .env.local
+set +a
+npm run build
+```
+
+### Firebase Hosting / RTDB deploy
+Once Firebase CLI is installed and authenticated:
+```bash
+set -a
+source .env.local
+set +a
 npm run build
 firebase deploy --only hosting,database
 ```
 
-If you deploy behind another web server instead of Firebase Hosting, serve the `dist/` folder at the path you built for. For `itsyasha.com/cuarenta`, build with `VITE_BASE_PATH=/cuarenta/` and keep SPA rewrites enabled.
+If you deploy behind another web server instead of Firebase Hosting, serve `dist/` at the same base path you built for and keep SPA rewrites enabled.
 
 ## Current limitations / follow-up
-- No auth UI. Identity is still a local browser-generated player id plus chosen name, so true seat ownership still wants anonymous/custom auth later.
+- No auth UI. Identity is still a local browser-generated player id plus chosen name, so true seat ownership still wants anonymous/custom auth.
 - Rejoin is intentionally same-browser and same-local-player-id. It is robust for refresh/disconnect/reopen, not for arbitrary device handoff.
 - Ronda-caida 10-point remembered bonus is not implemented yet.
 - The app auto-previews and auto-takes the full visible sequence for any chosen capture, so the real-world “missed sequence can be stolen by opponents” memory test is intentionally removed from the UI flow.
-- The UI is much more tactile now, but it is still a pragmatic drag-first web implementation, not full Hearthstone-grade animation/polish.
+- The UI is more intentional and compact than before, but it is still a pragmatic drag-first web implementation, not a fully animated premium card-game presentation.
+
+## Honest OSS-readiness status
+Current status: **not public-ready yet, but no longer casually dangerous by default**.
+
+The repo moved from “clone it and silently hit the live backend” toward “clone it and either use the emulator or opt into a real project on purpose.” The remaining real blocker before public visibility is the backend trust model, not the frontend build setup.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fresh React + Vite rewrite of the old repo.
 - Every game now gets a shareable rejoin URL (`?game=ABC123`) and the current browser remembers the last active session
 - Existing seated players can reopen the saved URL on the same browser and resume mid-game instead of getting locked out by the lobby-only join flow
 - Drag-first card play: drag onto the table to trail, onto highlighted board cards to match, or onto capture lanes / live targets for addition captures
-- Stronger move previews: the table now shows capture order, caída targets, scoring swing badges, and clearer turn-state feedback before you commit
+- Stronger move previews: hoverable board targets now carry distinct match/addition semantics, the table groups exact target vs sequence cards, and the UI shows capture order, caída targets, and scoring swing badges before you commit
 - In-app rules + scoring reference drawer for the high-value Cuarenta edge cases
 - Host vets joined names and starts when 4 seats are filled
 - Opening dealer is chosen randomly among the seated players for a fairer start

--- a/database.rules.json
+++ b/database.rules.json
@@ -7,7 +7,7 @@
       "$code": {
         ".read": true,
         ".write": "$code.matches(/^[A-HJ-NP-Z2-9]{6}$/)",
-        ".validate": "newData.exists() && newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('code').isString() && newData.child('code').val() === $code && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('hostId').isString() && newData.child('players').childrenCount() > 0 && newData.child('players').childrenCount() <= 4 && newData.child('players').hasChild(newData.child('hostId').val()) && newData.child('seating').childrenCount() > 0 && newData.child('seating').childrenCount() <= 4 && newData.child('scores').hasChildren(['A', 'B'])",
+        ".validate": "newData.exists() && newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('code').isString() && newData.child('code').val() === $code && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('hostId').isString() && newData.child('players').hasChild(newData.child('hostId').val()) && newData.child('seating/0').isString() && !newData.child('seating/4').exists() && newData.child('scores').hasChildren(['A', 'B'])",
         "code": {
           ".validate": "newData.isString() && newData.val() === $code"
         },
@@ -51,7 +51,7 @@
           }
         },
         "players": {
-          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          ".validate": "newData.hasChildren([newData.parent().child('hostId').val()])",
           "$playerId": {
             ".validate": "newData.hasChildren(['id', 'name', 'joinedAt', 'lastSeenAt', 'reconnectCount', 'isHost']) && newData.child('id').val() === $playerId && newData.child('name').isString() && newData.child('name').val().matches(/^.{1,24}$/) && newData.child('joinedAt').isNumber() && newData.child('lastSeenAt').isNumber() && newData.child('reconnectCount').isNumber() && newData.child('reconnectCount').val() >= 0 && newData.child('reconnectCount').val() <= 100 && newData.child('isHost').isBoolean() && (!newData.child('rejoinedAt').exists() || newData.child('rejoinedAt').isNumber())",
             "$other": {
@@ -60,7 +60,7 @@
           }
         },
         "seating": {
-          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          ".validate": "newData.child('0').isString() && !newData.child('4').exists()",
           "$other": {
             ".validate": "newData.isString()"
           }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,12 +1,102 @@
 {
   "rules": {
+    ".read": false,
+    ".write": false,
     "games": {
       ".read": true,
       "$code": {
+        ".read": true,
         ".write": "$code.matches(/^[A-HJ-NP-Z2-9]{6}$/)",
-        ".validate": "newData.exists() && newData.child('code').isString() && newData.child('code').val() === $code",
+        ".validate": "newData.exists() && newData.hasChildren(['code', 'status', 'hostId', 'createdAt', 'updatedAt', 'lastActivityAt', 'players', 'seating', 'scores', 'session']) && newData.child('code').isString() && newData.child('code').val() === $code && newData.child('status').isString() && (newData.child('status').val() === 'lobby' || newData.child('status').val() === 'playing' || newData.child('status').val() === 'finished') && newData.child('hostId').isString() && newData.child('players').childrenCount() > 0 && newData.child('players').childrenCount() <= 4 && newData.child('players').hasChild(newData.child('hostId').val()) && newData.child('seating').childrenCount() > 0 && newData.child('seating').childrenCount() <= 4 && newData.child('scores').hasChildren(['A', 'B'])",
         "code": {
           ".validate": "newData.isString() && newData.val() === $code"
+        },
+        "status": {
+          ".validate": "newData.isString() && (newData.val() === 'lobby' || newData.val() === 'playing' || newData.val() === 'finished')"
+        },
+        "hostId": {
+          ".validate": "newData.isString() && newData.val().matches(/^.{1,80}$/)"
+        },
+        "createdAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "updatedAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "lastActivityAt": {
+          ".validate": "newData.isNumber()"
+        },
+        "startedAt": {
+          ".validate": "!newData.exists() || newData.isNumber()"
+        },
+        "finishedAt": {
+          ".validate": "!newData.exists() || newData.isNumber()"
+        },
+        "lobbyMessage": {
+          ".validate": "!newData.exists() || (newData.isString() && newData.val().matches(/^.{0,120}$/))"
+        },
+        "winner": {
+          ".validate": "!newData.exists() || newData.val() === 'A' || newData.val() === 'B'"
+        },
+        "scores": {
+          ".validate": "newData.hasChildren(['A', 'B'])",
+          "A": {
+            ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 80"
+          },
+          "B": {
+            ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 80"
+          },
+          "$other": {
+            ".validate": false
+          }
+        },
+        "players": {
+          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          "$playerId": {
+            ".validate": "newData.hasChildren(['id', 'name', 'joinedAt', 'lastSeenAt', 'reconnectCount', 'isHost']) && newData.child('id').val() === $playerId && newData.child('name').isString() && newData.child('name').val().matches(/^.{1,24}$/) && newData.child('joinedAt').isNumber() && newData.child('lastSeenAt').isNumber() && newData.child('reconnectCount').isNumber() && newData.child('reconnectCount').val() >= 0 && newData.child('reconnectCount').val() <= 100 && newData.child('isHost').isBoolean() && (!newData.child('rejoinedAt').exists() || newData.child('rejoinedAt').isNumber())",
+            "$other": {
+              ".validate": true
+            }
+          }
+        },
+        "seating": {
+          ".validate": "newData.childrenCount() > 0 && newData.childrenCount() <= 4",
+          "$other": {
+            ".validate": "newData.isString()"
+          }
+        },
+        "session": {
+          ".validate": "newData.hasChildren(['version', 'reconnectable', 'createdAt', 'updatedAt'])",
+          "version": {
+            ".validate": "newData.isNumber() && newData.val() === 2"
+          },
+          "reconnectable": {
+            ".validate": "newData.isBoolean() && newData.val() === true"
+          },
+          "createdAt": {
+            ".validate": "newData.isNumber()"
+          },
+          "startedAt": {
+            ".validate": "!newData.exists() || newData.isNumber()"
+          },
+          "finishedAt": {
+            ".validate": "!newData.exists() || newData.isNumber()"
+          },
+          "updatedAt": {
+            ".validate": "newData.isNumber()"
+          },
+          "lastMoveAt": {
+            ".validate": "!newData.exists() || newData.isNumber()"
+          },
+          "lastAction": {
+            ".validate": "!newData.exists() || (newData.isString() && newData.val().matches(/^.{1,80}$/))"
+          },
+          "lastActorId": {
+            ".validate": "!newData.exists() || (newData.isString() && newData.val().matches(/^.{1,80}$/))"
+          },
+          "$other": {
+            ".validate": false
+          }
         },
         "$other": {
           ".validate": true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "firebase": "^12.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -291,70 +291,72 @@ function LobbySeat({ player, isCurrent, slot }) {
   );
 }
 
-function TurnOrder({ game, currentPlayerId }) {
+function MatchStatePanel({ game, currentPlayerId }) {
+  const teams = teamSummary(game);
+  const currentTeamId = game?.round?.teamsByPlayer?.[currentPlayerId]?.teamId;
+  const currentTurnName = game?.round?.turnPlayerId ? (game?.players?.[game.round.turnPlayerId]?.name || '—') : '—';
+
+  return (
+    <section className="sidebar-panel score-sidebar">
+      <div className="section-kicker">Match state</div>
+      <h2 className="sidebar-title">Board-side essentials</h2>
+      <div className="sidebar-scorecards">
+        {teams.map((team) => (
+          <div key={team.teamId} className={`side-team-card ${team.teamId === currentTeamId ? 'current-team' : ''}`}>
+            <div className="side-team-head">
+              <span className="side-team-label">Team {team.teamId}</span>
+              <div className="side-team-score">{team.score}<small>/40</small></div>
+            </div>
+            <div className="side-team-players">{team.players.map((player) => player?.name).filter(Boolean).join(' & ')}</div>
+            <div className="side-team-meta">Captured this hand <strong>{team.captured}</strong></div>
+          </div>
+        ))}
+      </div>
+      <div className="round-brief" aria-label="Round state">
+        <div>
+          <span>Hand</span>
+          <strong>{game?.round?.handNumber ?? '?'}</strong>
+        </div>
+        <div>
+          <span>Deal</span>
+          <strong>{game?.round?.activeDeal ?? '?'}</strong>
+        </div>
+        <div>
+          <span>Turn</span>
+          <strong>{currentTurnName}</strong>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TurnOrderPanel({ game, currentPlayerId }) {
   const seating = game?.seating?.map((id) => game.players[id]) || [];
   const currentTurn = game?.round?.turnPlayerId;
   const dealerPlayerId = getDealerPlayerId(game?.round, game?.seating);
-  const teams = teamSummary(game);
-  const currentTeamId = game?.round?.teamsByPlayer?.[currentPlayerId]?.teamId;
-  const currentTurnName = currentTurn ? (game?.players?.[currentTurn]?.name || '—') : '—';
 
   return (
-    <aside className="sidebar-column">
-      <section className="sidebar-panel score-sidebar">
-        <div className="section-kicker">Match state</div>
-        <h2 className="sidebar-title">Board-side essentials</h2>
-        <div className="sidebar-scorecards">
-          {teams.map((team) => (
-            <div key={team.teamId} className={`side-team-card ${team.teamId === currentTeamId ? 'current-team' : ''}`}>
-              <div className="side-team-head">
-                <span className="side-team-label">Team {team.teamId}</span>
-                <div className="side-team-score">{team.score}<small>/40</small></div>
+    <section className="activity-card order-card">
+      <div className="section-kicker">Table order</div>
+      <div className="activity-title">Who acts next</div>
+      <div className="timeline compact">
+        {seating.map((player, index) => (
+          <div key={player.id} className={`timeline-item ${currentTurn === player.id ? 'active' : ''}`}>
+            <div className="timeline-dot" />
+            <div className="timeline-copy">
+              <div className="timeline-kicker">{playerLabel(index, currentPlayerId, player, game.round, game)}</div>
+              <div className="timeline-row single-line">
+                <span className="timeline-name">{player.name}</span>
               </div>
-              <div className="side-team-players">{team.players.map((player) => player?.name).filter(Boolean).join(' & ')}</div>
-              <div className="side-team-meta">Captured this hand <strong>{team.captured}</strong></div>
-            </div>
-          ))}
-        </div>
-        <div className="round-brief" aria-label="Round state">
-          <div>
-            <span>Hand</span>
-            <strong>{game?.round?.handNumber ?? '?'}</strong>
-          </div>
-          <div>
-            <span>Deal</span>
-            <strong>{game?.round?.activeDeal ?? '?'}</strong>
-          </div>
-          <div>
-            <span>Turn</span>
-            <strong>{currentTurnName}</strong>
-          </div>
-        </div>
-      </section>
-
-      <section className="sidebar-panel">
-        <div className="section-kicker">Table order</div>
-        <h2 className="sidebar-title">Who acts next</h2>
-        <div className="timeline">
-          {seating.map((player, index) => (
-            <div key={player.id} className={`timeline-item ${currentTurn === player.id ? 'active' : ''}`}>
-              <div className="timeline-dot" />
-              <div className="timeline-copy">
-                <div className="timeline-kicker">{playerLabel(index, currentPlayerId, player, game.round, game)}</div>
-                <div className="timeline-row">
-                  <span className="timeline-name">{player.name}</span>
-                  <span className="timeline-score">{scoreForPlayer(game, player.id)}<small>/40</small></span>
-                </div>
-                <div className="timeline-flags">
-                  {player.id === dealerPlayerId ? <span className="timeline-flag">Dealer</span> : null}
-                  {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
-                </div>
+              <div className="timeline-flags">
+                {player.id === dealerPlayerId ? <span className="timeline-flag">Dealer</span> : null}
+                {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
               </div>
             </div>
-          ))}
-        </div>
-      </section>
-    </aside>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -642,47 +644,59 @@ function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, acti
   );
 }
 
-function ActivityPanel({ round, game, currentPlayerId, onCopyShareLink, linkCopied }) {
+function PlayerPanel({ round, game, currentPlayerId }) {
   const me = game?.players?.[currentPlayerId];
   const teamId = round?.teamsByPlayer?.[currentPlayerId]?.teamId;
   const seat = round?.teamsByPlayer?.[currentPlayerId]?.seat;
-  const recent = (round?.events || []).slice(0, 5);
   const dealerPlayerId = getDealerPlayerId(round, game?.seating);
   const dealerName = dealerPlayerId ? game?.players?.[dealerPlayerId]?.name : '';
 
   return (
-    <aside className="activity-column">
-      <div className="activity-card utility-card">
+    <section className="profile-card player-sidebar">
+      <div className="section-kicker">Player</div>
+      <div className="profile-avatar">{(me?.name || '?').slice(0, 1).toUpperCase()}</div>
+      <div className="profile-name">{me?.name || 'Player'}</div>
+      <div className="profile-sub">Seat {seat || '?'} · Team {teamId || '?'}</div>
+      <div className="profile-stats">
+        <div><span>Team score</span><strong>{teamId ? (game.scores?.[teamId] || 0) : 0}</strong></div>
+        <div><span>Cards won</span><strong>{teamId ? (round.capturedCardCount?.[teamId] || 0) : 0}</strong></div>
+      </div>
+      <div className="profile-tags">
+        {dealerName ? <span className="profile-tag">Dealer: {dealerName}</span> : null}
+        <span className="profile-tag">Goal: first to 40</span>
+      </div>
+    </section>
+  );
+}
+
+function RecentCallsPanel({ round }) {
+  const recent = (round?.events || []).slice(0, 5);
+
+  return (
+    <section className="activity-card recent-calls-card">
+      <div className="section-kicker">Recent table calls</div>
+      <div className="activity-title">Latest calls</div>
+      <ul>
+        {recent.map((event, index) => <li key={`${event}-${index}`}>{event}</li>)}
+      </ul>
+    </section>
+  );
+}
+
+function ReconnectDock({ game, onCopyShareLink, linkCopied }) {
+  return (
+    <details className="reconnect-dock">
+      <summary className="secondary-chip reconnect-summary">Reconnect</summary>
+      <div className="reconnect-popover">
         <div className="section-kicker">Reconnect</div>
-        <div className="activity-title">Keep the table link close</div>
+        <div className="reconnect-title">Keep the table link close</div>
         <p className="utility-copy">Same browser + same link reconnects cleanly. Device handoff still is not part of this build.</p>
         <div className="utility-row">
           <span className="profile-tag">Game {game?.code}</span>
           <button type="button" className="secondary-button utility-button" onClick={onCopyShareLink}>{linkCopied ? 'Link copied' : 'Copy rejoin link'}</button>
         </div>
       </div>
-
-      <div className="profile-card">
-        <div className="profile-avatar">{(me?.name || '?').slice(0, 1).toUpperCase()}</div>
-        <div className="profile-name">{me?.name || 'Player'}</div>
-        <div className="profile-sub">Seat {seat || '?'} · Team {teamId || '?'}</div>
-        <div className="profile-stats">
-          <div><span>Team score</span><strong>{teamId ? (game.scores?.[teamId] || 0) : 0}</strong></div>
-          <div><span>Cards won</span><strong>{teamId ? (round.capturedCardCount?.[teamId] || 0) : 0}</strong></div>
-        </div>
-        <div className="profile-tags">
-          {dealerName ? <span className="profile-tag">Dealer: {dealerName}</span> : null}
-          <span className="profile-tag">Goal: first to 40</span>
-        </div>
-      </div>
-
-      <div className="activity-card">
-        <div className="activity-title">Recent table calls</div>
-        <ul>
-          {recent.map((event, index) => <li key={`${event}-${index}`}>{event}</li>)}
-        </ul>
-      </div>
-    </aside>
+    </details>
   );
 }
 
@@ -1025,7 +1039,8 @@ export default function App() {
         <div className="topbar-actions">
           {showGameChrome ? <button type="button" className="secondary-chip" onClick={returnHome}>Home</button> : null}
           {showGameChrome ? <GameCode code={gameCode} /> : null}
-          {showGameChrome ? <button type="button" className="header-button" onClick={copyShareLink}>{linkCopied ? 'Link copied' : 'Share link'}</button> : null}
+          {game && round && isParticipant ? <ReconnectDock game={game} onCopyShareLink={copyShareLink} linkCopied={linkCopied} /> : null}
+          {showGameChrome && !(game && round && isParticipant) ? <button type="button" className="header-button" onClick={copyShareLink}>{linkCopied ? 'Link copied' : 'Share link'}</button> : null}
         </div>
       </header>
 
@@ -1113,7 +1128,10 @@ export default function App() {
 
       {game && round && isParticipant ? (
         <section className="game-layout">
-          <TurnOrder game={game} currentPlayerId={playerId} />
+          <aside className="sidebar-column">
+            <PlayerPanel round={round} game={game} currentPlayerId={playerId} />
+            <MatchStatePanel game={game} currentPlayerId={playerId} />
+          </aside>
           <section className="center-column">
             <TurnBanner
               game={game}
@@ -1160,13 +1178,10 @@ export default function App() {
             />
             {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
           </section>
-          <ActivityPanel
-            round={round}
-            game={game}
-            currentPlayerId={playerId}
-            onCopyShareLink={copyShareLink}
-            linkCopied={linkCopied}
-          />
+          <aside className="activity-column">
+            <TurnOrderPanel game={game} currentPlayerId={playerId} />
+            <RecentCallsPanel round={round} />
+          </aside>
         </section>
       ) : null}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { get, onValue, ref, runTransaction } from 'firebase/database';
 import { databaseUrl, db } from './lib/firebase';
 import { getLocalPlayerId, getSavedName, saveName } from './lib/localPlayer';
-import { applyMove, createInitialGameState, generateGameCode, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
+import { analyzeMove, applyMove, createInitialGameState, generateGameCode, getDealerPlayerId, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
 import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, isValidGameCode, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
 
 const REFERENCE_PANELS = {
@@ -87,38 +87,60 @@ function buildDirectDropMoves(moves) {
   );
 }
 
-function getMoveOutcome(round, game, playerId, move) {
-  if (!round || !game || !move) {
-    return {
-      captureCount: 0,
-      sequenceCount: 0,
-      isCaida: false,
-      isLimpia: false,
-      bonusPoints: 0,
-    };
+function buildPreviewTargetMeta(moves) {
+  const firstMoveByTarget = new Map();
+  const countsByTarget = new Map();
+
+  for (const move of moves) {
+    for (const targetId of move.targetIds || []) {
+      countsByTarget.set(targetId, (countsByTarget.get(targetId) || 0) + 1);
+      if (!firstMoveByTarget.has(targetId)) firstMoveByTarget.set(targetId, move);
+    }
   }
 
-  const captureSet = new Set(move.captureIds || []);
-  const targetCount = (move.targetIds || []).length;
-  const sequenceCount = Math.max(0, captureSet.size - targetCount);
-  const teamId = round.teamsByPlayer?.[playerId]?.teamId;
-  const scoreBefore = game.scores?.[teamId] || 0;
-  const remainingBoardCards = (round.board || []).filter((card) => !captureSet.has(card.id)).length;
-  const isCaida = move.type === 'match'
-    && Boolean(round.lastPlayedCard)
-    && move.targetIds?.[0] === round.lastPlayedCard.cardId
-    && round.lastPlayedCard.dealNumber === round.activeDeal
-    && round.lastPlayedCard.turnNumber === round.playsInCurrentDeal;
-  const isLimpia = move.type !== 'trail' && remainingBoardCards === 0 && scoreBefore < 38;
-  const bonusPoints = (isCaida ? 2 : 0) + (isLimpia ? 2 : 0);
+  return Object.fromEntries(
+    [...firstMoveByTarget.entries()].map(([targetId, move]) => [targetId, {
+      move,
+      previewKey: moveKey(move),
+      candidateCount: countsByTarget.get(targetId) || 1,
+    }])
+  );
+}
 
-  return {
-    captureCount: captureSet.size,
-    sequenceCount,
-    isCaida,
-    isLimpia,
-    bonusPoints,
-  };
+function moveTone(move) {
+  if (!move) return 'idle';
+  if (move.type === 'trail') return 'trail';
+  return move.type === 'match' ? 'match' : 'addition';
+}
+
+function moveKindLabel(move) {
+  if (!move) return 'Preview';
+  if (move.type === 'trail') return 'Trail';
+  return move.type === 'match' ? 'Match' : 'Addition';
+}
+
+function describePreviewGroups(move, boardCardsById) {
+  if (!move || move.type === 'trail') return [];
+  const targets = (move.targetIds || []).map((id) => boardCardsById[id]).filter(Boolean);
+  const targetIds = new Set(move.targetIds || []);
+  const extras = (move.captureIds || []).filter((id) => !targetIds.has(id)).map((id) => boardCardsById[id]).filter(Boolean);
+  const groups = [];
+
+  if (targets.length) {
+    groups.push({
+      label: move.type === 'match' ? 'Match target' : 'Add set',
+      cards: targets.map(cardText).join(' · '),
+    });
+  }
+
+  if (extras.length) {
+    groups.push({
+      label: 'Sequence run',
+      cards: extras.map(cardText).join(' · '),
+    });
+  }
+
+  return groups;
 }
 
 function describeMove(move, boardCardsById, outcome) {
@@ -163,38 +185,93 @@ function GameCode({ code }) {
   return <div className="share-pill">Game <strong>{code}</strong></div>;
 }
 
-function ReferenceDrawer({ tab, onClose }) {
+function ReferenceDrawer({ tab, onRequestClose, onTabChange }) {
+  const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
+
+  useEffect(() => {
+    if (!tab) return undefined;
+
+    const previousFocus = document.activeElement;
+    closeButtonRef.current?.focus();
+
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onRequestClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) return;
+      const focusables = [...dialogRef.current.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')]
+        .filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true');
+      if (!focusables.length) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (previousFocus instanceof HTMLElement) previousFocus.focus();
+    };
+  }, [onRequestClose, tab]);
+
   if (!tab) return null;
   const panel = REFERENCE_PANELS[tab] || REFERENCE_PANELS.rules;
+  const titleId = `reference-title-${tab}`;
+  const descriptionId = `reference-description-${tab}`;
 
   return (
-    <div className="reference-overlay" onClick={() => onClose('')} role="presentation">
-      <section className="reference-drawer" onClick={(event) => event.stopPropagation()}>
+    <div className="reference-overlay" onClick={onRequestClose} role="presentation">
+      <section
+        ref={dialogRef}
+        className="reference-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onClick={(event) => event.stopPropagation()}
+      >
         <div className="reference-head">
           <div>
             <div className="eyebrow">{panel.eyebrow}</div>
-            <h2>{panel.title}</h2>
+            <h2 id={titleId}>{panel.title}</h2>
           </div>
-          <button type="button" className="text-button" onClick={() => onClose('')}>Close</button>
+          <button ref={closeButtonRef} type="button" className="text-button" onClick={onRequestClose}>Close</button>
         </div>
-        <div className="reference-tabs">
+        <div className="reference-tabs" role="tablist" aria-label="Reference panels">
           {Object.entries(REFERENCE_PANELS).map(([key, value]) => (
             <button
               key={key}
+              id={`reference-tab-${key}`}
               type="button"
+              role="tab"
+              aria-selected={tab === key}
+              aria-controls={`reference-panel-${key}`}
               className={`reference-tab ${tab === key ? 'active' : ''}`}
-              onClick={() => onClose(key)}
+              onClick={() => onTabChange(key)}
             >
               {value.eyebrow}
             </button>
           ))}
         </div>
-        <p className="reference-lead">{panel.lead}</p>
-        <ul className="reference-list">
-          {panel.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
-        </ul>
-        <div className="reference-footer">
-          Source of truth: Pagat’s Cuarenta rules page. This UI also assumes full sequence capture whenever the sequence is visible.
+        <div id={`reference-panel-${tab}`} role="tabpanel" aria-labelledby={`reference-tab-${tab}`}>
+          <p id={descriptionId} className="reference-lead">{panel.lead}</p>
+          <ul className="reference-list">
+            {panel.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
+          </ul>
+          <div className="reference-footer">
+            Source of truth: Pagat’s Cuarenta rules page. This UI also assumes full sequence capture whenever the sequence is visible.
+          </div>
         </div>
       </section>
     </div>
@@ -217,7 +294,7 @@ function LobbySeat({ player, isCurrent, slot }) {
 function TurnOrder({ game, currentPlayerId }) {
   const seating = game?.seating?.map((id) => game.players[id]) || [];
   const currentTurn = game?.round?.turnPlayerId;
-  const dealerIndex = game?.round?.dealerIndex ?? -1;
+  const dealerPlayerId = getDealerPlayerId(game?.round, game?.seating);
 
   return (
     <aside className="sidebar-panel">
@@ -234,7 +311,7 @@ function TurnOrder({ game, currentPlayerId }) {
                 <span className="timeline-score">{scoreForPlayer(game, player.id)}<small>/40</small></span>
               </div>
               <div className="timeline-flags">
-                {index === dealerIndex ? <span className="timeline-flag">Dealer</span> : null}
+                {player.id === dealerPlayerId ? <span className="timeline-flag">Dealer</span> : null}
                 {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
               </div>
             </div>
@@ -311,14 +388,17 @@ function TurnBanner({ game, round, currentPlayerId, activeCard, movesForActiveCa
   );
 }
 
-function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlightedTargetIds, captureOrderMap, directDropMoves, trailMove, dragCardId, onPlay, lastPlayedCardId, previewedMove, previewCopy }) {
+function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlightedTargetIds, captureOrderMap, directDropMoves, previewTargetMeta, trailMove, dragCardId, onPlay, onPreview, lastPlayedCardId, previewedMove, previewOutcome, previewCopy, boardCardsById }) {
   const safeCards = Array.isArray(cards) ? cards : [];
   const highlighted = new Set(highlightedCaptureIds || []);
   const targets = new Set(highlightedTargetIds || []);
   const trailArmed = Boolean(trailMove) && dragCardId === trailMove.playedCardId;
+  const previewToneClass = moveTone(previewedMove);
+  const previewGroups = describePreviewGroups(previewedMove, boardCardsById);
+  const sequenceIds = new Set((previewedMove?.captureIds || []).filter((id) => !targets.has(id)));
 
   return (
-    <section className={`board-shell ${trailArmed ? 'board-shell-armed' : ''}`}>
+    <section className={`board-shell ${trailArmed ? 'board-shell-armed' : ''} preview-tone-${previewToneClass}`}>
       <div className="board-hud">
         <div className="hud-chip">Deck {deckRemaining}</div>
         <div className="hud-chip accent">{canLimpia ? 'Limpia available' : 'No limpia at 38+'}</div>
@@ -327,10 +407,13 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlig
 
       <div
         className={`table-grid ${trailArmed ? 'is-drop-target' : ''}`}
+        onMouseEnter={() => trailArmed && trailMove && onPreview(moveKey(trailMove))}
+        onMouseLeave={() => onPreview('')}
         onDragOver={(event) => {
           if (!trailArmed) return;
           event.preventDefault();
           event.dataTransfer.dropEffect = 'move';
+          if (trailMove) onPreview(moveKey(trailMove));
         }}
         onDrop={(event) => {
           if (!trailArmed || !trailMove) return;
@@ -341,25 +424,41 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlig
         {safeCards.length ? safeCards.map((card, index) => {
           const directMove = directDropMoves?.[card.id];
           const canDirectDrop = Boolean(directMove) && dragCardId === directMove.playedCardId;
+          const previewMeta = previewTargetMeta?.[card.id];
           const captureStep = captureOrderMap?.[card.id];
           const isLastPlayed = lastPlayedCardId === card.id;
+          const isSequenceCard = sequenceIds.has(card.id);
+          const toneClass = previewMeta ? `tone-${moveTone(previewMeta.move)}` : '';
+          const targetLabel = previewMeta
+            ? (previewMeta.candidateCount > 1 ? `${previewMeta.candidateCount} lines` : moveKindLabel(previewMeta.move))
+            : '';
+          const CardTag = directMove ? 'button' : 'div';
 
           return (
-            <div
+            <CardTag
               key={card.id}
+              type={directMove ? 'button' : undefined}
               className={[
                 'stitch-card',
                 'board-card',
                 cardSuitClass(card),
                 highlighted.has(card.id) ? 'is-highlighted' : '',
                 targets.has(card.id) ? 'is-target-card' : '',
+                isSequenceCard ? 'is-sequence-card' : '',
+                previewMeta ? 'has-preview-target' : '',
+                toneClass,
                 directMove ? 'is-click-target' : '',
                 canDirectDrop ? 'is-direct-target' : '',
                 isLastPlayed ? 'is-last-played' : '',
               ].filter(Boolean).join(' ')}
               style={{ '--card-tilt': boardCardTilt(index) }}
               onClick={() => directMove && onPlay(directMove)}
+              onMouseEnter={() => previewMeta && onPreview(previewMeta.previewKey)}
+              onMouseLeave={() => previewMeta && onPreview('')}
+              onFocus={() => previewMeta && onPreview(previewMeta.previewKey)}
+              onBlur={() => previewMeta && onPreview('')}
               onDragOver={(event) => {
+                if (previewMeta) onPreview(previewMeta.previewKey);
                 if (!canDirectDrop) return;
                 event.preventDefault();
                 event.dataTransfer.dropEffect = 'move';
@@ -371,20 +470,42 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlig
                 onPlay(directMove);
               }}
             >
+              {previewMeta ? <div className={`card-target-tag ${toneClass}`}>{targetLabel}</div> : null}
               {isLastPlayed ? <div className="card-status-tag">Last card</div> : null}
               {captureStep ? <div className="capture-step-tag">{captureStep}</div> : null}
               <div className="card-corner">{card.rank}</div>
               <div className="card-center">{card.suit}</div>
               <div className="card-corner bottom">{card.rank}</div>
-            </div>
+            </CardTag>
           );
         }) : <div className="empty-table">No cards on the felt yet.</div>}
       </div>
 
       {previewedMove ? (
-        <div className={`board-preview ${previewedMove.type === 'trail' ? 'trail' : 'capture'}`}>
-          <div className="board-preview-kicker">{previewedMove.type === 'trail' ? 'Trail preview' : 'Capture preview'}</div>
-          <div className="board-preview-copy">{previewCopy}</div>
+        <div className={`board-preview ${previewToneClass}`}>
+          <div className="board-preview-head">
+            <div>
+              <div className="board-preview-kicker">{moveKindLabel(previewedMove)} preview</div>
+              <div className="board-preview-copy">{previewCopy}</div>
+            </div>
+            <div className="board-preview-badges">
+              <span className={`preview-pill tone-${previewToneClass}`}>{moveKindLabel(previewedMove)}</span>
+              {previewOutcome?.sequenceCount > 0 ? <span className="preview-pill">Run +{previewOutcome.sequenceCount}</span> : null}
+              {previewOutcome?.isCaida ? <span className="preview-pill bonus">Caída +2</span> : null}
+              {previewOutcome?.isLimpia ? <span className="preview-pill bonus">Limpia +2</span> : null}
+              {previewedMove.type === 'trail' ? <span className="preview-pill subtle">No capture</span> : null}
+            </div>
+          </div>
+          {previewGroups.length ? (
+            <div className="board-preview-groups">
+              {previewGroups.map((group) => (
+                <div key={`${group.label}-${group.cards}`} className="preview-group-row">
+                  <span className="preview-group-label">{group.label}</span>
+                  <span className="preview-group-cards">{group.cards}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
       ) : null}
     </section>
@@ -394,7 +515,8 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlig
 function MoveOptionCard({ move, playedCard, boardCardsById, moveOutcome, isPreviewed, dragCardId, onPreview, onPlay }) {
   const captureCards = (move.captureIds || []).map((id) => boardCardsById[id]).filter(Boolean);
   const canDrop = dragCardId === move.playedCardId;
-  const kindLabel = move.type === 'trail' ? 'Trail' : move.type === 'match' ? 'Match' : 'Addition';
+  const kindLabel = moveKindLabel(move);
+  const toneClass = moveTone(move);
   const chips = [];
 
   if (move.type !== 'trail') chips.push(`${moveOutcome.captureCount} table card${moveOutcome.captureCount === 1 ? '' : 's'}`);
@@ -406,7 +528,7 @@ function MoveOptionCard({ move, playedCard, boardCardsById, moveOutcome, isPrevi
   return (
     <button
       type="button"
-      className={`move-option ${isPreviewed ? 'previewed' : ''} ${canDrop ? 'drop-ready' : ''}`}
+      className={`move-option tone-${toneClass} ${isPreviewed ? 'previewed' : ''} ${canDrop ? 'drop-ready' : ''}`}
       onClick={() => onPlay(move)}
       onMouseEnter={() => onPreview(moveKey(move))}
       onMouseLeave={() => onPreview('')}
@@ -424,7 +546,7 @@ function MoveOptionCard({ move, playedCard, boardCardsById, moveOutcome, isPrevi
       }}
     >
       <div className="move-option-head">
-        <span className="move-kind">{kindLabel}</span>
+        <span className={`move-kind tone-${toneClass}`}>{kindLabel}</span>
         <span className="move-kicker">{moveOutcome.bonusPoints ? `+${moveOutcome.bonusPoints} swing` : canDrop ? 'Drop to play' : 'Click to play'}</span>
       </div>
       {move.type === 'trail' ? (
@@ -439,7 +561,7 @@ function MoveOptionCard({ move, playedCard, boardCardsById, moveOutcome, isPrevi
         </div>
       )}
       <div className="move-badges">
-        {chips.map((chip) => <span key={chip} className="move-badge">{chip}</span>)}
+        {chips.map((chip) => <span key={chip} className={`move-badge tone-${toneClass}`}>{chip}</span>)}
       </div>
       <div className="move-label">{describeMove(move, boardCardsById, moveOutcome)}</div>
     </button>
@@ -515,7 +637,8 @@ function ActivityPanel({ round, game, currentPlayerId }) {
   const teamId = round?.teamsByPlayer?.[currentPlayerId]?.teamId;
   const seat = round?.teamsByPlayer?.[currentPlayerId]?.seat;
   const recent = (round?.events || []).slice(0, 5);
-  const dealerName = game?.players?.[round?.turnOrder?.[round?.dealerIndex]]?.name;
+  const dealerPlayerId = getDealerPlayerId(round, game?.seating);
+  const dealerName = dealerPlayerId ? game?.players?.[dealerPlayerId]?.name : '';
 
   return (
     <aside className="activity-column">
@@ -678,8 +801,8 @@ export default function App() {
   const visibleHand = round ? (getVisibleHand(round, playerId) || []) : [];
   const legalMoves = round ? (getLegalMoves(round, playerId) || []) : [];
   const moveOutcomes = useMemo(
-    () => Object.fromEntries(legalMoves.map((move) => [moveKey(move), getMoveOutcome(round, game, playerId, move)])),
-    [game, legalMoves, playerId, round]
+    () => Object.fromEntries(legalMoves.map((move) => [moveKey(move), analyzeMove(game, playerId, move)])),
+    [game, legalMoves, playerId]
   );
   const isHost = game?.hostId === playerId;
   const isYourTurn = round?.turnPlayerId === playerId;
@@ -689,12 +812,19 @@ export default function App() {
   const activeCard = visibleHand.find((card) => card.id === activeCardId) || visibleHand[0] || null;
   const movesForActiveCard = legalMoves.filter((move) => move.playedCardId === activeCard?.id);
   const captureMovesForActiveCard = movesForActiveCard.filter((move) => move.type !== 'trail');
-  const previewedMove = movesForActiveCard.find((move) => moveKey(move) === previewMoveKey) || null;
+  const previewedMove = movesForActiveCard.find((move) => moveKey(move) === previewMoveKey)
+    || captureMovesForActiveCard[0]
+    || movesForActiveCard[0]
+    || null;
   const trailMove = movesForActiveCard.find((move) => move.type === 'trail') || null;
   const previewOutcome = previewedMove ? moveOutcomes[moveKey(previewedMove)] : null;
   const previewCopy = previewedMove ? describeMove(previewedMove, boardCardsById, previewOutcome || {}) : '';
   const directDropMoves = useMemo(
     () => buildDirectDropMoves(captureMovesForActiveCard),
+    [captureMovesForActiveCard]
+  );
+  const previewTargetMeta = useMemo(
+    () => buildPreviewTargetMeta(captureMovesForActiveCard),
     [captureMovesForActiveCard]
   );
   const highlightedCaptureIds = previewedMove?.captureIds || [];
@@ -866,8 +996,24 @@ export default function App() {
         <div className="brand-block">
           <div className="brand">Cuarenta</div>
           <nav className="topnav">
-            <button type="button" className={referenceTab === 'rules' ? 'active' : ''} onClick={() => setReferenceTab(referenceTab === 'rules' ? '' : 'rules')}>Rules</button>
-            <button type="button" className={referenceTab === 'scoring' ? 'active' : ''} onClick={() => setReferenceTab(referenceTab === 'scoring' ? '' : 'scoring')}>Scoring</button>
+            <button
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={referenceTab === 'rules'}
+              className={referenceTab === 'rules' ? 'active' : ''}
+              onClick={() => setReferenceTab(referenceTab === 'rules' ? '' : 'rules')}
+            >
+              Rules
+            </button>
+            <button
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={referenceTab === 'scoring'}
+              className={referenceTab === 'scoring' ? 'active' : ''}
+              onClick={() => setReferenceTab(referenceTab === 'scoring' ? '' : 'scoring')}
+            >
+              Scoring
+            </button>
           </nav>
         </div>
         <div className="topbar-actions">
@@ -877,7 +1023,7 @@ export default function App() {
         </div>
       </header>
 
-      <ReferenceDrawer tab={referenceTab} onClose={(nextTab = '') => setReferenceTab(nextTab)} />
+      <ReferenceDrawer tab={referenceTab} onRequestClose={() => setReferenceTab('')} onTabChange={setReferenceTab} />
 
       {showHome ? (
         <section className="lobby-shell invite-mode">
@@ -993,12 +1139,16 @@ export default function App() {
                 highlightedTargetIds={highlightedTargetIds}
                 captureOrderMap={captureOrderMap}
                 directDropMoves={directDropMoves}
+                previewTargetMeta={previewTargetMeta}
                 trailMove={trailMove}
                 dragCardId={dragCardId}
                 onPlay={playChosenMove}
+                onPreview={setPreviewMoveKey}
                 lastPlayedCardId={lastPlayedCardId}
                 previewedMove={previewedMove}
+                previewOutcome={previewOutcome}
                 previewCopy={previewCopy}
+                boardCardsById={boardCardsById}
               />
               <MovePicker
                 hand={visibleHand}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { get, onValue, ref, runTransaction } from 'firebase/database';
-import { databaseUrl, db } from './lib/firebase';
+import { db, firebaseConfigError, firebaseMode, hasFirebase } from './lib/firebase';
 import { getLocalPlayerId, getSavedName, saveName } from './lib/localPlayer';
 import { analyzeMove, applyMove, createInitialGameState, generateGameCode, getDealerPlayerId, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
 import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, isValidGameCode, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
@@ -295,53 +295,66 @@ function TurnOrder({ game, currentPlayerId }) {
   const seating = game?.seating?.map((id) => game.players[id]) || [];
   const currentTurn = game?.round?.turnPlayerId;
   const dealerPlayerId = getDealerPlayerId(game?.round, game?.seating);
+  const teams = teamSummary(game);
+  const currentTeamId = game?.round?.teamsByPlayer?.[currentPlayerId]?.teamId;
+  const currentTurnName = currentTurn ? (game?.players?.[currentTurn]?.name || '—') : '—';
 
   return (
-    <aside className="sidebar-panel">
-      <div className="section-kicker">Table order</div>
-      <h2 className="sidebar-title">Who acts next</h2>
-      <div className="timeline">
-        {seating.map((player, index) => (
-          <div key={player.id} className={`timeline-item ${currentTurn === player.id ? 'active' : ''}`}>
-            <div className="timeline-dot" />
-            <div className="timeline-copy">
-              <div className="timeline-kicker">{playerLabel(index, currentPlayerId, player, game.round, game)}</div>
-              <div className="timeline-row">
-                <span className="timeline-name">{player.name}</span>
-                <span className="timeline-score">{scoreForPlayer(game, player.id)}<small>/40</small></span>
+    <aside className="sidebar-column">
+      <section className="sidebar-panel score-sidebar">
+        <div className="section-kicker">Match state</div>
+        <h2 className="sidebar-title">Board-side essentials</h2>
+        <div className="sidebar-scorecards">
+          {teams.map((team) => (
+            <div key={team.teamId} className={`side-team-card ${team.teamId === currentTeamId ? 'current-team' : ''}`}>
+              <div className="side-team-head">
+                <span className="side-team-label">Team {team.teamId}</span>
+                <div className="side-team-score">{team.score}<small>/40</small></div>
               </div>
-              <div className="timeline-flags">
-                {player.id === dealerPlayerId ? <span className="timeline-flag">Dealer</span> : null}
-                {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
+              <div className="side-team-players">{team.players.map((player) => player?.name).filter(Boolean).join(' & ')}</div>
+              <div className="side-team-meta">Captured this hand <strong>{team.captured}</strong></div>
+            </div>
+          ))}
+        </div>
+        <div className="round-brief" aria-label="Round state">
+          <div>
+            <span>Hand</span>
+            <strong>{game?.round?.handNumber ?? '?'}</strong>
+          </div>
+          <div>
+            <span>Deal</span>
+            <strong>{game?.round?.activeDeal ?? '?'}</strong>
+          </div>
+          <div>
+            <span>Turn</span>
+            <strong>{currentTurnName}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="sidebar-panel">
+        <div className="section-kicker">Table order</div>
+        <h2 className="sidebar-title">Who acts next</h2>
+        <div className="timeline">
+          {seating.map((player, index) => (
+            <div key={player.id} className={`timeline-item ${currentTurn === player.id ? 'active' : ''}`}>
+              <div className="timeline-dot" />
+              <div className="timeline-copy">
+                <div className="timeline-kicker">{playerLabel(index, currentPlayerId, player, game.round, game)}</div>
+                <div className="timeline-row">
+                  <span className="timeline-name">{player.name}</span>
+                  <span className="timeline-score">{scoreForPlayer(game, player.id)}<small>/40</small></span>
+                </div>
+                <div className="timeline-flags">
+                  {player.id === dealerPlayerId ? <span className="timeline-flag">Dealer</span> : null}
+                  {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      </section>
     </aside>
-  );
-}
-
-function TeamCard({ team, isCurrentTeam }) {
-  const progress = Math.min(100, Math.round((team.score / 40) * 100));
-
-  return (
-    <div className={`team-stat ${isCurrentTeam ? 'current-team' : ''}`}>
-      <div className="team-stat-head">
-        <div>
-          <div className="team-stat-title">Team {team.teamId}</div>
-          <div className="team-stat-players">{team.players.map((player) => player?.name).join(' & ')}</div>
-        </div>
-        <div className="team-score-stack">
-          <strong>{team.score}</strong>
-          <span>/40</span>
-        </div>
-      </div>
-      <div className="team-progress" aria-hidden="true">
-        <div className="team-progress-fill" style={{ width: `${progress}%` }} />
-      </div>
-      <div className="team-stat-line">Captured this hand <strong>{team.captured}</strong></div>
-    </div>
   );
 }
 
@@ -355,30 +368,28 @@ function TurnBanner({ game, round, currentPlayerId, activeCard, movesForActiveCa
   const lastPlayedCard = lastPlayedCardId ? boardCardsById[lastPlayedCardId] : null;
   const currentTurnName = game.players?.[round.turnPlayerId]?.name || 'the table';
 
-  let headline = `Waiting for ${currentTurnName}.`;
-  let body = 'Watch the felt, count what is gone, and stay ready for the swing card.';
+  let headline = `Waiting on ${currentTurnName}.`;
+  let body = 'Read the felt, count what is gone, and hold back the answer card.';
 
   if (isYourTurn) {
-    headline = activeCard ? `Your turn — ${cardText(activeCard)} is live.` : 'Your turn — choose a card.';
+    headline = activeCard ? `Your turn — ${cardText(activeCard)} ready.` : 'Your turn — pick the card.';
     if (captureMoves.length === 0) {
-      body = 'No clean capture is showing. Trail something that keeps your left side uncomfortable.';
+      body = 'No clean take is live. Trail something awkward.';
     } else if (captureMoves.length === 1) {
-      body = 'One clear capture line is available. Drag onto the glowing target or use the lane below.';
+      body = 'One clean line is live. Drag fast or inspect the lane below.';
     } else {
-      body = `${captureMoves.length} different capture lines are live. Preview one, then commit the cleanest hit.`;
+      body = `${captureMoves.length} capture lines are live. Preview, then hit the cleanest one.`;
     }
   }
 
   return (
     <section className={`turn-banner ${isYourTurn ? 'is-live' : 'is-waiting'}`}>
-      <div>
-        <div className="section-kicker">Round control</div>
+      <div className="turn-banner-copy">
+        <div className="section-kicker">On the felt</div>
         <h2>{headline}</h2>
         <p>{body}</p>
       </div>
       <div className="turn-banner-chips">
-        <span className="turn-chip">Hand {round.handNumber}</span>
-        <span className="turn-chip">Deal {round.activeDeal}</span>
         {activeCard ? <span className="turn-chip emphasis">Selected {cardText(activeCard)}</span> : null}
         {lastPlayedCard ? <span className="turn-chip warning">Caída target: {cardText(lastPlayedCard)}</span> : null}
         {liveCaida ? <span className="turn-chip bonus">Caída live</span> : null}
@@ -402,7 +413,6 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlig
       <div className="board-hud">
         <div className="hud-chip">Deck {deckRemaining}</div>
         <div className="hud-chip accent">{canLimpia ? 'Limpia available' : 'No limpia at 38+'}</div>
-        <div className="hud-chip subdued">Drag to the felt or a live target</div>
       </div>
 
       <div
@@ -632,7 +642,7 @@ function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, acti
   );
 }
 
-function ActivityPanel({ round, game, currentPlayerId }) {
+function ActivityPanel({ round, game, currentPlayerId, onCopyShareLink, linkCopied }) {
   const me = game?.players?.[currentPlayerId];
   const teamId = round?.teamsByPlayer?.[currentPlayerId]?.teamId;
   const seat = round?.teamsByPlayer?.[currentPlayerId]?.seat;
@@ -642,6 +652,16 @@ function ActivityPanel({ round, game, currentPlayerId }) {
 
   return (
     <aside className="activity-column">
+      <div className="activity-card utility-card">
+        <div className="section-kicker">Reconnect</div>
+        <div className="activity-title">Keep the table link close</div>
+        <p className="utility-copy">Same browser + same link reconnects cleanly. Device handoff still is not part of this build.</p>
+        <div className="utility-row">
+          <span className="profile-tag">Game {game?.code}</span>
+          <button type="button" className="secondary-button utility-button" onClick={onCopyShareLink}>{linkCopied ? 'Link copied' : 'Copy rejoin link'}</button>
+        </div>
+      </div>
+
       <div className="profile-card">
         <div className="profile-avatar">{(me?.name || '?').slice(0, 1).toUpperCase()}</div>
         <div className="profile-name">{me?.name || 'Player'}</div>
@@ -655,6 +675,7 @@ function ActivityPanel({ round, game, currentPlayerId }) {
           <span className="profile-tag">Goal: first to 40</span>
         </div>
       </div>
+
       <div className="activity-card">
         <div className="activity-title">Recent table calls</div>
         <ul>
@@ -681,10 +702,9 @@ export default function App() {
   const [gameCode, setGameCode] = useState(initialUrlCode || initialSavedSession?.gameCode || '');
   const [savedSession, setSavedSession] = useState(initialSavedSession);
   const [game, setGame] = useState(null);
-  const [gameLoadState, setGameLoadState] = useState(gameCode ? 'loading' : 'idle');
+  const [gameLoadState, setGameLoadState] = useState(gameCode && hasFirebase ? 'loading' : 'idle');
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
-  const [dbStatus, setDbStatus] = useState('checking');
   const [linkCopied, setLinkCopied] = useState(false);
   const [selectedCardId, setSelectedCardId] = useState('');
   const [dragCardId, setDragCardId] = useState('');
@@ -692,7 +712,7 @@ export default function App() {
   const [referenceTab, setReferenceTab] = useState('');
 
   const playerId = useMemo(() => getLocalPlayerId(), []);
-  const gameRef = useMemo(() => (gameCode ? ref(db, `games/${gameCode}`) : null), [gameCode]);
+  const gameRef = useMemo(() => (gameCode && hasFirebase ? ref(db, `games/${gameCode}`) : null), [gameCode]);
 
   function rememberSession(code) {
     saveGameSession(code);
@@ -739,22 +759,6 @@ export default function App() {
   }, [gameCode]);
 
   useEffect(() => {
-    let cancelled = false;
-    async function checkDbAccess() {
-      try {
-        const response = await fetch(`${databaseUrl}/games.json?shallow=true`);
-        if (!cancelled) setDbStatus(response.ok ? 'ok' : response.status === 401 ? 'read-denied' : 'error');
-      } catch {
-        if (!cancelled) setDbStatus('error');
-      }
-    }
-    checkDbAccess();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
     if (!gameRef) {
       setGame(null);
       setGameLoadState('idle');
@@ -791,7 +795,6 @@ export default function App() {
 
   const seating = game?.seating?.map((id) => game.players[id]);
   const isParticipant = Boolean(game?.players?.[playerId]);
-  const teams = teamSummary(game);
   const round = game?.round;
   const boardCards = Array.isArray(round?.board) ? round.board : [];
   const boardCardsById = useMemo(
@@ -860,7 +863,7 @@ export default function App() {
   async function createGame() {
     const trimmed = name.trim();
     if (!trimmed) return setError('Enter your name first.');
-    if (dbStatus === 'read-denied') return setError('RTDB public reads are currently blocked, so lobby creation cannot work yet. Update the live database rules first.');
+    if (!hasFirebase) return setError(firebaseConfigError || 'Firebase is not configured for this build.');
     saveName(trimmed);
     setBusy(true);
     setError('');
@@ -893,7 +896,7 @@ export default function App() {
     const trimmed = name.trim();
     const code = normalizeGameCode(gameCode || joinCode);
     if (!trimmed || !isValidGameCode(code)) return setError('Enter your name and a valid 6-character game code.');
-    if (dbStatus === 'read-denied') return setError('RTDB public reads are currently blocked, so joining cannot work yet. Update the live database rules first.');
+    if (!hasFirebase) return setError(firebaseConfigError || 'Firebase is not configured for this build.');
     saveName(trimmed);
     setBusy(true);
     setError('');
@@ -960,6 +963,7 @@ export default function App() {
   }
 
   async function startGame() {
+    if (!hasFirebase) return setError(firebaseConfigError || 'Firebase is not configured for this build.');
     if (!game || game.hostId !== playerId) return;
     if ((game.seating || []).length !== 4) return setError('Need exactly 4 players.');
     setBusy(true);
@@ -974,6 +978,7 @@ export default function App() {
   }
 
   async function playChosenMove(move) {
+    if (!hasFirebase) return setError(firebaseConfigError || 'Firebase is not configured for this build.');
     if (!move) return;
     setDragCardId('');
     setPreviewMoveKey('');
@@ -986,8 +991,9 @@ export default function App() {
     setBusy(false);
   }
 
-  const showHome = !gameCode || gameLoadState === 'missing';
-  const showGameChrome = Boolean(gameCode) && gameLoadState !== 'missing';
+  const firebaseUnavailable = firebaseMode === 'unconfigured';
+  const showHome = !gameCode || gameLoadState === 'missing' || firebaseUnavailable;
+  const showGameChrome = Boolean(gameCode) && gameLoadState !== 'missing' && !firebaseUnavailable;
   const shareUrl = showGameChrome ? buildGameUrl(gameCode) : '';
 
   return (
@@ -1043,11 +1049,11 @@ export default function App() {
               <input value={name} onChange={(event) => setName(event.target.value)} maxLength={24} placeholder="Mateo V." />
             </label>
             <div className="button-stack">
-              <button className="primary-button" disabled={busy || dbStatus === 'checking'} onClick={createGame}>Host game</button>
+              <button className="primary-button" disabled={busy || !hasFirebase} onClick={createGame}>Host game</button>
             </div>
             <div className="join-inline">
               <input value={joinCode} onChange={(event) => setJoinCode(normalizeGameCode(event.target.value))} placeholder="Enter code" maxLength={6} />
-              <button className="secondary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Join</button>
+              <button className="secondary-button" disabled={busy || !hasFirebase} onClick={joinGame}>Join</button>
             </div>
             <div className="ghost-note">This browser remembers the current seat, so a refresh does not quietly murder the match.</div>
           </section>
@@ -1066,9 +1072,9 @@ export default function App() {
         </section>
       ) : null}
 
-      {dbStatus === 'read-denied' ? (
+      {firebaseUnavailable ? (
         <section className="notice-card">
-          The live Firebase Realtime Database still rejects public reads for the game path. With the current no-auth design, host and join will not work until those live rules are deployed.
+          {firebaseConfigError}
         </section>
       ) : null}
 
@@ -1093,7 +1099,7 @@ export default function App() {
                 Your name
                 <input value={name} onChange={(event) => setName(event.target.value)} maxLength={24} placeholder="Mateo V." />
               </label>
-              <button className="primary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Take a seat</button>
+              <button className="primary-button" disabled={busy || !hasFirebase} onClick={joinGame}>Take a seat</button>
               <div className="ghost-note">Open this same link later on this browser and you will land back in the game instead of getting bounced to the lobby.</div>
             </section>
           ) : (
@@ -1106,69 +1112,62 @@ export default function App() {
       ) : null}
 
       {game && round && isParticipant ? (
-        <>
-          <section className="notice-card slim-note">
-            Refresh-safe session is active for <strong>{game.code}</strong>. Reopen the same link on this browser to reconnect mid-match.
+        <section className="game-layout">
+          <TurnOrder game={game} currentPlayerId={playerId} />
+          <section className="center-column">
+            <TurnBanner
+              game={game}
+              round={round}
+              currentPlayerId={playerId}
+              activeCard={activeCard}
+              movesForActiveCard={movesForActiveCard}
+              moveOutcomes={moveOutcomes}
+              lastPlayedCardId={lastPlayedCardId}
+              boardCardsById={boardCardsById}
+            />
+            <Board
+              cards={round.board}
+              deckRemaining={round.deckRemaining}
+              canLimpia={canLimpia}
+              highlightedCaptureIds={highlightedCaptureIds}
+              highlightedTargetIds={highlightedTargetIds}
+              captureOrderMap={captureOrderMap}
+              directDropMoves={directDropMoves}
+              previewTargetMeta={previewTargetMeta}
+              trailMove={trailMove}
+              dragCardId={dragCardId}
+              onPlay={playChosenMove}
+              onPreview={setPreviewMoveKey}
+              lastPlayedCardId={lastPlayedCardId}
+              previewedMove={previewedMove}
+              previewOutcome={previewOutcome}
+              previewCopy={previewCopy}
+              boardCardsById={boardCardsById}
+            />
+            <MovePicker
+              hand={visibleHand}
+              legalMoves={legalMoves}
+              boardCardsById={boardCardsById}
+              onPlay={playChosenMove}
+              isYourTurn={isYourTurn}
+              activeCardId={activeCardId}
+              setSelectedCardId={setSelectedCardId}
+              dragCardId={dragCardId}
+              setDragCardId={setDragCardId}
+              previewMoveKey={previewMoveKey}
+              setPreviewMoveKey={setPreviewMoveKey}
+              moveOutcomes={moveOutcomes}
+            />
+            {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
           </section>
-          <section className="game-layout">
-            <TurnOrder game={game} currentPlayerId={playerId} />
-            <section className="center-column">
-              <div className="team-stats-row">
-                {teams.map((team) => <TeamCard key={team.teamId} team={team} isCurrentTeam={team.teamId === currentTeamId} />)}
-                <div className="phase-card">
-                  <div className="team-stat-title">Round state</div>
-                  <div className="phase-name">Hand {round.handNumber} · Deal {round.activeDeal}</div>
-                  <div className="phase-turn">Turn: {game.players[round.turnPlayerId]?.name}</div>
-                </div>
-              </div>
-              <TurnBanner
-                game={game}
-                round={round}
-                currentPlayerId={playerId}
-                activeCard={activeCard}
-                movesForActiveCard={movesForActiveCard}
-                moveOutcomes={moveOutcomes}
-                lastPlayedCardId={lastPlayedCardId}
-                boardCardsById={boardCardsById}
-              />
-              <Board
-                cards={round.board}
-                deckRemaining={round.deckRemaining}
-                canLimpia={canLimpia}
-                highlightedCaptureIds={highlightedCaptureIds}
-                highlightedTargetIds={highlightedTargetIds}
-                captureOrderMap={captureOrderMap}
-                directDropMoves={directDropMoves}
-                previewTargetMeta={previewTargetMeta}
-                trailMove={trailMove}
-                dragCardId={dragCardId}
-                onPlay={playChosenMove}
-                onPreview={setPreviewMoveKey}
-                lastPlayedCardId={lastPlayedCardId}
-                previewedMove={previewedMove}
-                previewOutcome={previewOutcome}
-                previewCopy={previewCopy}
-                boardCardsById={boardCardsById}
-              />
-              <MovePicker
-                hand={visibleHand}
-                legalMoves={legalMoves}
-                boardCardsById={boardCardsById}
-                onPlay={playChosenMove}
-                isYourTurn={isYourTurn}
-                activeCardId={activeCardId}
-                setSelectedCardId={setSelectedCardId}
-                dragCardId={dragCardId}
-                setDragCardId={setDragCardId}
-                previewMoveKey={previewMoveKey}
-                setPreviewMoveKey={setPreviewMoveKey}
-                moveOutcomes={moveOutcomes}
-              />
-              {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
-            </section>
-            <ActivityPanel round={round} game={game} currentPlayerId={playerId} />
-          </section>
-        </>
+          <ActivityPanel
+            round={round}
+            game={game}
+            currentPlayerId={playerId}
+            onCopyShareLink={copyShareLink}
+            linkCopied={linkCopied}
+          />
+        </section>
       ) : null}
 
       {game && round && !isParticipant ? (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,12 +5,41 @@ import { getLocalPlayerId, getSavedName, saveName } from './lib/localPlayer';
 import { applyMove, createInitialGameState, generateGameCode, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
 import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, isValidGameCode, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
 
+const REFERENCE_PANELS = {
+  rules: {
+    eyebrow: 'Table law',
+    title: 'How captures work in this build',
+    lead: 'This version follows the Pagat rules source the repo cites, but it makes the sequence part explicit so the UI stays honest under pressure.',
+    bullets: [
+      'A play can capture by matching the same rank or by addition with A-7 only. If several captures are possible, you choose exactly one set.',
+      'Sequence only happens after a successful match or addition capture, and it runs upward through A-2-3-4-5-6-7-J-Q-K.',
+      'The app previews the full sequence automatically. That means you do not need to remember extra sequence cards yourself mid-move.',
+      'Caída only comes from the next player immediately matching the card just played. Addition and sequence do not count as caída.',
+    ],
+  },
+  scoring: {
+    eyebrow: 'Scorekeeping',
+    title: 'High-value scoring quirks worth remembering',
+    lead: 'Cuarenta gets swingy fast, so the drawer keeps the annoying edge cases close instead of hiding them in README land.',
+    bullets: [
+      'Limpia is +2 for clearing the table. Caída y limpia stack for +4 when both happen together.',
+      'A team on 38 cannot collect limpia. A team on 36 can still win with caída y limpia.',
+      'Ronda is +4 only while your team is under 30. The special remembered ronda-caída +10 bonus is still not implemented here.',
+      'At the end of the hand, loose cards left on the table do not belong to either team unless the final play was a limpia.',
+    ],
+  },
+};
+
 function moveKey(move) {
   return `${move.type}:${move.playedCardId}:${(move.captureIds || []).join(',')}`;
 }
 
 function cardText(card) {
   return `${card.rank}${card.suit}`;
+}
+
+function cardSuitClass(card) {
+  return card?.suit === '♥' || card?.suit === '♦' ? 'is-red' : 'is-dark';
 }
 
 function playerLabel(index, currentPlayerId, seatPlayer, round, game) {
@@ -29,8 +58,89 @@ function scoreForPlayer(game, playerId) {
   return game.scores?.[teamId] || 0;
 }
 
-function cardSuitClass(card) {
-  return card?.suit === '♥' || card?.suit === '♦' ? 'is-red' : 'is-dark';
+function cardTilt(index, count = 1) {
+  if (count <= 1) return '0deg';
+  const midpoint = (count - 1) / 2;
+  return `${(index - midpoint) * 2.2}deg`;
+}
+
+function boardCardTilt(index) {
+  return `${((index % 5) - 2) * 1.6}deg`;
+}
+
+function buildDirectDropMoves(moves) {
+  const candidateByTarget = new Map();
+  const ambiguous = new Set();
+
+  for (const move of moves) {
+    for (const targetId of move.targetIds || []) {
+      if (candidateByTarget.has(targetId) && moveKey(candidateByTarget.get(targetId)) !== moveKey(move)) {
+        ambiguous.add(targetId);
+        continue;
+      }
+      candidateByTarget.set(targetId, move);
+    }
+  }
+
+  return Object.fromEntries(
+    [...candidateByTarget.entries()].filter(([targetId]) => !ambiguous.has(targetId))
+  );
+}
+
+function getMoveOutcome(round, game, playerId, move) {
+  if (!round || !game || !move) {
+    return {
+      captureCount: 0,
+      sequenceCount: 0,
+      isCaida: false,
+      isLimpia: false,
+      bonusPoints: 0,
+    };
+  }
+
+  const captureSet = new Set(move.captureIds || []);
+  const targetCount = (move.targetIds || []).length;
+  const sequenceCount = Math.max(0, captureSet.size - targetCount);
+  const teamId = round.teamsByPlayer?.[playerId]?.teamId;
+  const scoreBefore = game.scores?.[teamId] || 0;
+  const remainingBoardCards = (round.board || []).filter((card) => !captureSet.has(card.id)).length;
+  const isCaida = move.type === 'match'
+    && Boolean(round.lastPlayedCard)
+    && move.targetIds?.[0] === round.lastPlayedCard.cardId
+    && round.lastPlayedCard.dealNumber === round.activeDeal
+    && round.lastPlayedCard.turnNumber === round.playsInCurrentDeal;
+  const isLimpia = move.type !== 'trail' && remainingBoardCards === 0 && scoreBefore < 38;
+  const bonusPoints = (isCaida ? 2 : 0) + (isLimpia ? 2 : 0);
+
+  return {
+    captureCount: captureSet.size,
+    sequenceCount,
+    isCaida,
+    isLimpia,
+    bonusPoints,
+  };
+}
+
+function describeMove(move, boardCardsById, outcome) {
+  if (!move) return '';
+  if (move.type === 'trail') return 'Leave the card on the felt and keep the table live.';
+
+  const targets = (move.targetIds || []).map((id) => boardCardsById[id]).filter(Boolean).map(cardText);
+  const captured = (move.captureIds || []).map((id) => boardCardsById[id]).filter(Boolean);
+  const highest = captured.at(-1);
+
+  if (move.type === 'match') {
+    if (outcome.sequenceCount > 0 && highest) {
+      return `Match clean, then run the sequence through ${cardText(highest)}.`;
+    }
+    return `Snap the matching rank and take it clean.`;
+  }
+
+  const setText = targets.join(' + ');
+  if (outcome.sequenceCount > 0 && highest) {
+    return `Add ${setText}, then keep collecting upward through ${cardText(highest)}.`;
+  }
+  return `Add ${setText} exactly and take the set.`;
 }
 
 function stampSessionMetadata(target, { now = Date.now(), action, actorId }) {
@@ -53,6 +163,44 @@ function GameCode({ code }) {
   return <div className="share-pill">Game <strong>{code}</strong></div>;
 }
 
+function ReferenceDrawer({ tab, onClose }) {
+  if (!tab) return null;
+  const panel = REFERENCE_PANELS[tab] || REFERENCE_PANELS.rules;
+
+  return (
+    <div className="reference-overlay" onClick={() => onClose('')} role="presentation">
+      <section className="reference-drawer" onClick={(event) => event.stopPropagation()}>
+        <div className="reference-head">
+          <div>
+            <div className="eyebrow">{panel.eyebrow}</div>
+            <h2>{panel.title}</h2>
+          </div>
+          <button type="button" className="text-button" onClick={() => onClose('')}>Close</button>
+        </div>
+        <div className="reference-tabs">
+          {Object.entries(REFERENCE_PANELS).map(([key, value]) => (
+            <button
+              key={key}
+              type="button"
+              className={`reference-tab ${tab === key ? 'active' : ''}`}
+              onClick={() => onClose(key)}
+            >
+              {value.eyebrow}
+            </button>
+          ))}
+        </div>
+        <p className="reference-lead">{panel.lead}</p>
+        <ul className="reference-list">
+          {panel.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
+        </ul>
+        <div className="reference-footer">
+          Source of truth: Pagat’s Cuarenta rules page. This UI also assumes full sequence capture whenever the sequence is visible.
+        </div>
+      </section>
+    </div>
+  );
+}
+
 function LobbySeat({ player, isCurrent, slot }) {
   return (
     <div className={`lobby-seat ${player ? 'filled' : 'empty'} ${isCurrent ? 'current' : ''}`}>
@@ -69,10 +217,12 @@ function LobbySeat({ player, isCurrent, slot }) {
 function TurnOrder({ game, currentPlayerId }) {
   const seating = game?.seating?.map((id) => game.players[id]) || [];
   const currentTurn = game?.round?.turnPlayerId;
+  const dealerIndex = game?.round?.dealerIndex ?? -1;
 
   return (
     <aside className="sidebar-panel">
-      <h2 className="sidebar-title">Turn Order</h2>
+      <div className="section-kicker">Table order</div>
+      <h2 className="sidebar-title">Who acts next</h2>
       <div className="timeline">
         {seating.map((player, index) => (
           <div key={player.id} className={`timeline-item ${currentTurn === player.id ? 'active' : ''}`}>
@@ -83,6 +233,10 @@ function TurnOrder({ game, currentPlayerId }) {
                 <span className="timeline-name">{player.name}</span>
                 <span className="timeline-score">{scoreForPlayer(game, player.id)}<small>/40</small></span>
               </div>
+              <div className="timeline-flags">
+                {index === dealerIndex ? <span className="timeline-flag">Dealer</span> : null}
+                {currentTurn === player.id ? <span className="timeline-flag current">On move</span> : null}
+              </div>
             </div>
           </div>
         ))}
@@ -91,17 +245,86 @@ function TurnOrder({ game, currentPlayerId }) {
   );
 }
 
-function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, directDropMoves, trailMove, dragCardId, onPlay }) {
+function TeamCard({ team, isCurrentTeam }) {
+  const progress = Math.min(100, Math.round((team.score / 40) * 100));
+
+  return (
+    <div className={`team-stat ${isCurrentTeam ? 'current-team' : ''}`}>
+      <div className="team-stat-head">
+        <div>
+          <div className="team-stat-title">Team {team.teamId}</div>
+          <div className="team-stat-players">{team.players.map((player) => player?.name).join(' & ')}</div>
+        </div>
+        <div className="team-score-stack">
+          <strong>{team.score}</strong>
+          <span>/40</span>
+        </div>
+      </div>
+      <div className="team-progress" aria-hidden="true">
+        <div className="team-progress-fill" style={{ width: `${progress}%` }} />
+      </div>
+      <div className="team-stat-line">Captured this hand <strong>{team.captured}</strong></div>
+    </div>
+  );
+}
+
+function TurnBanner({ game, round, currentPlayerId, activeCard, movesForActiveCard, moveOutcomes, lastPlayedCardId, boardCardsById }) {
+  if (!game || !round) return null;
+
+  const isYourTurn = round.turnPlayerId === currentPlayerId;
+  const captureMoves = movesForActiveCard.filter((move) => move.type !== 'trail');
+  const liveCaida = captureMoves.some((move) => moveOutcomes[moveKey(move)]?.isCaida);
+  const liveLimpia = captureMoves.some((move) => moveOutcomes[moveKey(move)]?.isLimpia);
+  const lastPlayedCard = lastPlayedCardId ? boardCardsById[lastPlayedCardId] : null;
+  const currentTurnName = game.players?.[round.turnPlayerId]?.name || 'the table';
+
+  let headline = `Waiting for ${currentTurnName}.`;
+  let body = 'Watch the felt, count what is gone, and stay ready for the swing card.';
+
+  if (isYourTurn) {
+    headline = activeCard ? `Your turn — ${cardText(activeCard)} is live.` : 'Your turn — choose a card.';
+    if (captureMoves.length === 0) {
+      body = 'No clean capture is showing. Trail something that keeps your left side uncomfortable.';
+    } else if (captureMoves.length === 1) {
+      body = 'One clear capture line is available. Drag onto the glowing target or use the lane below.';
+    } else {
+      body = `${captureMoves.length} different capture lines are live. Preview one, then commit the cleanest hit.`;
+    }
+  }
+
+  return (
+    <section className={`turn-banner ${isYourTurn ? 'is-live' : 'is-waiting'}`}>
+      <div>
+        <div className="section-kicker">Round control</div>
+        <h2>{headline}</h2>
+        <p>{body}</p>
+      </div>
+      <div className="turn-banner-chips">
+        <span className="turn-chip">Hand {round.handNumber}</span>
+        <span className="turn-chip">Deal {round.activeDeal}</span>
+        {activeCard ? <span className="turn-chip emphasis">Selected {cardText(activeCard)}</span> : null}
+        {lastPlayedCard ? <span className="turn-chip warning">Caída target: {cardText(lastPlayedCard)}</span> : null}
+        {liveCaida ? <span className="turn-chip bonus">Caída live</span> : null}
+        {liveLimpia ? <span className="turn-chip bonus">Limpia live</span> : null}
+      </div>
+    </section>
+  );
+}
+
+function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, highlightedTargetIds, captureOrderMap, directDropMoves, trailMove, dragCardId, onPlay, lastPlayedCardId, previewedMove, previewCopy }) {
   const safeCards = Array.isArray(cards) ? cards : [];
   const highlighted = new Set(highlightedCaptureIds || []);
+  const targets = new Set(highlightedTargetIds || []);
   const trailArmed = Boolean(trailMove) && dragCardId === trailMove.playedCardId;
 
   return (
     <section className={`board-shell ${trailArmed ? 'board-shell-armed' : ''}`}>
       <div className="board-hud">
-        <div className="hud-chip">Deck: {deckRemaining}</div>
-        <div className="hud-chip accent">{canLimpia ? 'Limpia live' : 'No limpia bonus'}</div>
+        <div className="hud-chip">Deck {deckRemaining}</div>
+        <div className="hud-chip accent">{canLimpia ? 'Limpia available' : 'No limpia at 38+'}</div>
+        <div className="hud-chip subdued">Drag to the felt or a live target</div>
       </div>
+
       <div
         className={`table-grid ${trailArmed ? 'is-drop-target' : ''}`}
         onDragOver={(event) => {
@@ -115,14 +338,26 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, directD
           onPlay(trailMove);
         }}
       >
-        {safeCards.length ? safeCards.map((card) => {
+        {safeCards.length ? safeCards.map((card, index) => {
           const directMove = directDropMoves?.[card.id];
           const canDirectDrop = Boolean(directMove) && dragCardId === directMove.playedCardId;
+          const captureStep = captureOrderMap?.[card.id];
+          const isLastPlayed = lastPlayedCardId === card.id;
 
           return (
             <div
               key={card.id}
-              className={`stitch-card board-card ${cardSuitClass(card)} ${highlighted.has(card.id) ? 'is-highlighted' : ''} ${directMove ? 'is-click-target' : ''} ${canDirectDrop ? 'is-direct-target' : ''}`}
+              className={[
+                'stitch-card',
+                'board-card',
+                cardSuitClass(card),
+                highlighted.has(card.id) ? 'is-highlighted' : '',
+                targets.has(card.id) ? 'is-target-card' : '',
+                directMove ? 'is-click-target' : '',
+                canDirectDrop ? 'is-direct-target' : '',
+                isLastPlayed ? 'is-last-played' : '',
+              ].filter(Boolean).join(' ')}
+              style={{ '--card-tilt': boardCardTilt(index) }}
               onClick={() => directMove && onPlay(directMove)}
               onDragOver={(event) => {
                 if (!canDirectDrop) return;
@@ -136,21 +371,37 @@ function Board({ cards, deckRemaining, canLimpia, highlightedCaptureIds, directD
                 onPlay(directMove);
               }}
             >
+              {isLastPlayed ? <div className="card-status-tag">Last card</div> : null}
+              {captureStep ? <div className="capture-step-tag">{captureStep}</div> : null}
               <div className="card-corner">{card.rank}</div>
               <div className="card-center">{card.suit}</div>
               <div className="card-corner bottom">{card.rank}</div>
             </div>
           );
-        }) : <div className="empty-table">No cards on the table yet</div>}
+        }) : <div className="empty-table">No cards on the felt yet.</div>}
       </div>
+
+      {previewedMove ? (
+        <div className={`board-preview ${previewedMove.type === 'trail' ? 'trail' : 'capture'}`}>
+          <div className="board-preview-kicker">{previewedMove.type === 'trail' ? 'Trail preview' : 'Capture preview'}</div>
+          <div className="board-preview-copy">{previewCopy}</div>
+        </div>
+      ) : null}
     </section>
   );
 }
 
-function MoveOptionCard({ move, boardCardsById, isPreviewed, dragCardId, onPreview, onPlay }) {
+function MoveOptionCard({ move, playedCard, boardCardsById, moveOutcome, isPreviewed, dragCardId, onPreview, onPlay }) {
   const captureCards = (move.captureIds || []).map((id) => boardCardsById[id]).filter(Boolean);
   const canDrop = dragCardId === move.playedCardId;
-  const kindLabel = move.type === 'trail' ? 'Trail' : move.type === 'match' ? 'Match' : 'Add capture';
+  const kindLabel = move.type === 'trail' ? 'Trail' : move.type === 'match' ? 'Match' : 'Addition';
+  const chips = [];
+
+  if (move.type !== 'trail') chips.push(`${moveOutcome.captureCount} table card${moveOutcome.captureCount === 1 ? '' : 's'}`);
+  if (moveOutcome.sequenceCount > 0) chips.push(`Sequence +${moveOutcome.sequenceCount}`);
+  if (moveOutcome.isCaida) chips.push('Caída +2');
+  if (moveOutcome.isLimpia) chips.push('Limpia +2');
+  if (move.type === 'trail') chips.push('No capture');
 
   return (
     <button
@@ -174,37 +425,47 @@ function MoveOptionCard({ move, boardCardsById, isPreviewed, dragCardId, onPrevi
     >
       <div className="move-option-head">
         <span className="move-kind">{kindLabel}</span>
-        <span className="move-kicker">{move.type === 'trail' ? 'Drop on table' : `${captureCards.length} captured`}</span>
+        <span className="move-kicker">{moveOutcome.bonusPoints ? `+${moveOutcome.bonusPoints} swing` : canDrop ? 'Drop to play' : 'Click to play'}</span>
       </div>
-      {captureCards.length ? (
-        <div className="move-capture-row">
-          {captureCards.map((card) => <span key={card.id} className={`mini-card ${cardSuitClass(card)}`}>{cardText(card)}</span>)}
-        </div>
+      {move.type === 'trail' ? (
+        <div className="move-empty-target">Leave {cardText(playedCard)} on the table.</div>
       ) : (
-        <div className="move-empty-target">Open table drop</div>
+        <div className="move-lineup">
+          <span className={`mini-card played ${cardSuitClass(playedCard)}`}>{cardText(playedCard)}</span>
+          <span className="move-arrow">→</span>
+          <div className="move-capture-row">
+            {captureCards.map((card) => <span key={card.id} className={`mini-card ${cardSuitClass(card)}`}>{cardText(card)}</span>)}
+          </div>
+        </div>
       )}
-      <div className="move-label">{move.label}</div>
+      <div className="move-badges">
+        {chips.map((chip) => <span key={chip} className="move-badge">{chip}</span>)}
+      </div>
+      <div className="move-label">{describeMove(move, boardCardsById, moveOutcome)}</div>
     </button>
   );
 }
 
-function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, selectedCardId, setSelectedCardId, dragCardId, setDragCardId, previewMoveKey, setPreviewMoveKey }) {
-  const activeCardId = dragCardId || selectedCardId || hand[0]?.id || '';
-  const movesForCard = legalMoves.filter((move) => move.playedCardId === activeCardId);
+function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, activeCardId, setSelectedCardId, dragCardId, setDragCardId, previewMoveKey, setPreviewMoveKey, moveOutcomes }) {
+  const handCardsById = useMemo(() => Object.fromEntries(hand.map((card) => [card.id, card])), [hand]);
+  const activeCard = handCardsById[activeCardId] || hand[0] || null;
+  const movesForCard = legalMoves.filter((move) => move.playedCardId === activeCard?.id);
+  const orderedMoves = [...movesForCard.filter((move) => move.type !== 'trail'), ...movesForCard.filter((move) => move.type === 'trail')];
 
   return (
     <section className="hand-shell">
       <div className="hand-head">
         <span>Your hand</span>
-        <span className="hand-kicker">Drag cards like a civilized person</span>
+        <span className="hand-kicker">Pick the swing card, then aim with intent</span>
       </div>
       <div className="hand-row stitch-hand-row">
-        {hand.map((card) => (
+        {hand.map((card, index) => (
           <button
             key={card.id}
             type="button"
             draggable={isYourTurn}
-            className={`stitch-card hand-card ${cardSuitClass(card)} ${selectedCardId === card.id ? 'selected' : ''} ${dragCardId === card.id ? 'dragging' : ''}`}
+            className={`stitch-card hand-card ${cardSuitClass(card)} ${activeCardId === card.id ? 'selected' : ''} ${dragCardId === card.id ? 'dragging' : ''}`}
+            style={{ '--card-tilt': cardTilt(index, hand.length) }}
             onClick={() => setSelectedCardId(card.id)}
             onDragStart={(event) => {
               setSelectedCardId(card.id);
@@ -225,13 +486,17 @@ function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, sele
       </div>
       {isYourTurn ? (
         <div className="play-controls">
-          <div className="ghost-note">Drag onto the table to trail, onto a highlighted board card to match, or onto one of the capture lanes below.</div>
+          <div className="ghost-note">
+            {activeCard ? `Capture lanes for ${cardText(activeCard)}. Drag to a live target for speed, or click a lane if you want the exact call spelled out first.` : 'Choose a card to see its capture lines.'}
+          </div>
           <div className="move-options-grid">
-            {movesForCard.map((move) => (
+            {orderedMoves.map((move) => (
               <MoveOptionCard
                 key={moveKey(move)}
                 move={move}
+                playedCard={handCardsById[move.playedCardId]}
                 boardCardsById={boardCardsById}
+                moveOutcome={moveOutcomes[moveKey(move)]}
                 isPreviewed={previewMoveKey === moveKey(move)}
                 dragCardId={dragCardId}
                 onPreview={setPreviewMoveKey}
@@ -240,43 +505,37 @@ function MovePicker({ hand, legalMoves, boardCardsById, onPlay, isYourTurn, sele
             ))}
           </div>
         </div>
-      ) : <div className="muted-note">Waiting for your turn.</div>}
+      ) : <div className="muted-note">Waiting for your turn. Count what is gone and keep your partner’s lane in mind.</div>}
     </section>
-  );
-}
-
-function TeamCard({ team }) {
-  return (
-    <div className="team-stat">
-      <div className="team-stat-title">Team {team.teamId}</div>
-      <div className="team-stat-players">{team.players.map((player) => player?.name).join(' & ')}</div>
-      <div className="team-stat-line">Score <strong>{team.score}</strong></div>
-      <div className="team-stat-line">Captured this hand {team.captured}</div>
-    </div>
   );
 }
 
 function ActivityPanel({ round, game, currentPlayerId }) {
   const me = game?.players?.[currentPlayerId];
-  const caidaEvents = (round?.events || []).filter((event) => /\(\+2\)|ca[ií]da/i.test(event)).slice(0, 1);
-  const limpiaEvents = (round?.events || []).filter((event) => /limpia/i.test(event)).slice(0, 1);
-  const remaining = (round?.events || []).slice(0, 4);
+  const teamId = round?.teamsByPlayer?.[currentPlayerId]?.teamId;
+  const seat = round?.teamsByPlayer?.[currentPlayerId]?.seat;
+  const recent = (round?.events || []).slice(0, 5);
+  const dealerName = game?.players?.[round?.turnOrder?.[round?.dealerIndex]]?.name;
 
   return (
     <aside className="activity-column">
       <div className="profile-card">
         <div className="profile-avatar">{(me?.name || '?').slice(0, 1).toUpperCase()}</div>
         <div className="profile-name">{me?.name || 'Player'}</div>
-        <div className="profile-sub">Maestro de Cuarenta</div>
+        <div className="profile-sub">Seat {seat || '?'} · Team {teamId || '?'}</div>
         <div className="profile-stats">
-          <div><span>Caídas</span><strong>{caidaEvents.length}</strong></div>
-          <div><span>Limpias</span><strong>{limpiaEvents.length}</strong></div>
+          <div><span>Team score</span><strong>{teamId ? (game.scores?.[teamId] || 0) : 0}</strong></div>
+          <div><span>Cards won</span><strong>{teamId ? (round.capturedCardCount?.[teamId] || 0) : 0}</strong></div>
+        </div>
+        <div className="profile-tags">
+          {dealerName ? <span className="profile-tag">Dealer: {dealerName}</span> : null}
+          <span className="profile-tag">Goal: first to 40</span>
         </div>
       </div>
       <div className="activity-card">
-        <div className="activity-title">Activity</div>
+        <div className="activity-title">Recent table calls</div>
         <ul>
-          {remaining.map((event, index) => <li key={`${event}-${index}`}>{event}</li>)}
+          {recent.map((event, index) => <li key={`${event}-${index}`}>{event}</li>)}
         </ul>
       </div>
     </aside>
@@ -307,6 +566,7 @@ export default function App() {
   const [selectedCardId, setSelectedCardId] = useState('');
   const [dragCardId, setDragCardId] = useState('');
   const [previewMoveKey, setPreviewMoveKey] = useState('');
+  const [referenceTab, setReferenceTab] = useState('');
 
   const playerId = useMemo(() => getLocalPlayerId(), []);
   const gameRef = useMemo(() => (gameCode ? ref(db, `games/${gameCode}`) : null), [gameCode]);
@@ -417,20 +677,37 @@ export default function App() {
   );
   const visibleHand = round ? (getVisibleHand(round, playerId) || []) : [];
   const legalMoves = round ? (getLegalMoves(round, playerId) || []) : [];
+  const moveOutcomes = useMemo(
+    () => Object.fromEntries(legalMoves.map((move) => [moveKey(move), getMoveOutcome(round, game, playerId, move)])),
+    [game, legalMoves, playerId, round]
+  );
   const isHost = game?.hostId === playerId;
   const isYourTurn = round?.turnPlayerId === playerId;
   const currentTeamId = round?.teamsByPlayer?.[playerId]?.teamId;
   const canLimpia = round ? ((game?.scores?.[currentTeamId] || 0) < 38) : false;
   const activeCardId = dragCardId || selectedCardId || visibleHand[0]?.id || '';
-  const movesForActiveCard = legalMoves.filter((move) => move.playedCardId === activeCardId);
+  const activeCard = visibleHand.find((card) => card.id === activeCardId) || visibleHand[0] || null;
+  const movesForActiveCard = legalMoves.filter((move) => move.playedCardId === activeCard?.id);
+  const captureMovesForActiveCard = movesForActiveCard.filter((move) => move.type !== 'trail');
   const previewedMove = movesForActiveCard.find((move) => moveKey(move) === previewMoveKey) || null;
   const trailMove = movesForActiveCard.find((move) => move.type === 'trail') || null;
-  const directDropMoves = useMemo(() => {
-    const entries = movesForActiveCard
-      .filter((move) => move.type === 'match' && move.targetIds?.length === 1)
-      .map((move) => [move.targetIds[0], move]);
-    return Object.fromEntries(entries);
-  }, [movesForActiveCard]);
+  const previewOutcome = previewedMove ? moveOutcomes[moveKey(previewedMove)] : null;
+  const previewCopy = previewedMove ? describeMove(previewedMove, boardCardsById, previewOutcome || {}) : '';
+  const directDropMoves = useMemo(
+    () => buildDirectDropMoves(captureMovesForActiveCard),
+    [captureMovesForActiveCard]
+  );
+  const highlightedCaptureIds = previewedMove?.captureIds || [];
+  const highlightedTargetIds = previewedMove?.targetIds || [];
+  const captureOrderMap = useMemo(
+    () => Object.fromEntries((previewedMove?.captureIds || []).map((id, index) => [id, index + 1])),
+    [previewedMove]
+  );
+  const lastPlayedCardId = round?.lastPlayedCard
+    && round.lastPlayedCard.dealNumber === round.activeDeal
+    && round.lastPlayedCard.turnNumber === round.playsInCurrentDeal
+    ? round.lastPlayedCard.cardId
+    : null;
 
   useEffect(() => {
     if (!visibleHand.some((card) => card.id === selectedCardId)) {
@@ -439,10 +716,16 @@ export default function App() {
   }, [visibleHand, selectedCardId]);
 
   useEffect(() => {
-    if (!movesForActiveCard.some((move) => moveKey(move) === previewMoveKey)) {
-      setPreviewMoveKey('');
+    const validKeys = movesForActiveCard.map((move) => moveKey(move));
+    if (!validKeys.length) {
+      if (previewMoveKey) setPreviewMoveKey('');
+      return;
     }
-  }, [movesForActiveCard, previewMoveKey]);
+    if (!validKeys.includes(previewMoveKey)) {
+      const preferred = captureMovesForActiveCard[0] || movesForActiveCard[0];
+      setPreviewMoveKey(preferred ? moveKey(preferred) : '');
+    }
+  }, [captureMovesForActiveCard, movesForActiveCard, previewMoveKey]);
 
   async function createGame() {
     const trimmed = name.trim();
@@ -561,6 +844,7 @@ export default function App() {
   }
 
   async function playChosenMove(move) {
+    if (!move) return;
     setDragCardId('');
     setPreviewMoveKey('');
     setBusy(true);
@@ -582,8 +866,8 @@ export default function App() {
         <div className="brand-block">
           <div className="brand">Cuarenta</div>
           <nav className="topnav">
-            <span>Rules</span>
-            <span>History</span>
+            <button type="button" className={referenceTab === 'rules' ? 'active' : ''} onClick={() => setReferenceTab(referenceTab === 'rules' ? '' : 'rules')}>Rules</button>
+            <button type="button" className={referenceTab === 'scoring' ? 'active' : ''} onClick={() => setReferenceTab(referenceTab === 'scoring' ? '' : 'scoring')}>Scoring</button>
           </nav>
         </div>
         <div className="topbar-actions">
@@ -593,12 +877,14 @@ export default function App() {
         </div>
       </header>
 
+      <ReferenceDrawer tab={referenceTab} onClose={(nextTab = '') => setReferenceTab(nextTab)} />
+
       {showHome ? (
         <section className="lobby-shell invite-mode">
           <div className="invite-copy">
-            <div className="eyebrow">Lobby Invitation</div>
+            <div className="eyebrow">Lobby invitation</div>
             <h1>Host or Join a Match</h1>
-            <p>Classic four-player Cuarenta with reconnectable links, saved local sessions, and drag-first card play.</p>
+            <p>Classic four-player Cuarenta with reconnectable links, better move previews, and a felt-first drag flow that explains what will happen before you commit.</p>
           </div>
           {gameLoadState === 'missing' && gameCode ? (
             <section className="notice-card">
@@ -617,7 +903,7 @@ export default function App() {
               <input value={joinCode} onChange={(event) => setJoinCode(normalizeGameCode(event.target.value))} placeholder="Enter code" maxLength={6} />
               <button className="secondary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Join</button>
             </div>
-            <div className="ghost-note">When you join from a link, this browser remembers the session so a refresh does not nuke the match.</div>
+            <div className="ghost-note">This browser remembers the current seat, so a refresh does not quietly murder the match.</div>
           </section>
           {savedSession ? (
             <section className="resume-card">
@@ -645,9 +931,9 @@ export default function App() {
       {game && game.status === 'lobby' ? (
         <section className="lobby-shell">
           <div className="invite-copy centered">
-            <div className="eyebrow">Lobby Invitation</div>
+            <div className="eyebrow">Lobby invitation</div>
             <h1>{game.code.split('').join('-')}</h1>
-            <p>{game.lobbyMessage || 'Share this code with three friends to start a classic match of Cuarenta.'}</p>
+            <p>{game.lobbyMessage || 'Share this code with three friends and let the table talk begin.'}</p>
           </div>
           <section className="notice-card slim-note">
             Rejoin URL: <strong>{shareUrl}</strong>
@@ -662,11 +948,11 @@ export default function App() {
                 <input value={name} onChange={(event) => setName(event.target.value)} maxLength={24} placeholder="Mateo V." />
               </label>
               <button className="primary-button" disabled={busy || dbStatus === 'checking'} onClick={joinGame}>Take a seat</button>
-              <div className="ghost-note">Open this same link later on this browser and you will land back in the game instead of being locked out.</div>
+              <div className="ghost-note">Open this same link later on this browser and you will land back in the game instead of getting bounced to the lobby.</div>
             </section>
           ) : (
             <div className="lobby-actions">
-              {isHost ? <button className="primary-button wide" disabled={busy || (game.seating || []).length !== 4} onClick={startGame}>Start Game</button> : null}
+              {isHost ? <button className="primary-button wide" disabled={busy || (game.seating || []).length !== 4} onClick={startGame}>Start game</button> : null}
               <div className="lobby-footnote">Requires 4 players to begin</div>
             </div>
           )}
@@ -682,22 +968,37 @@ export default function App() {
             <TurnOrder game={game} currentPlayerId={playerId} />
             <section className="center-column">
               <div className="team-stats-row">
-                {teams.map((team) => <TeamCard key={team.teamId} team={team} />)}
+                {teams.map((team) => <TeamCard key={team.teamId} team={team} isCurrentTeam={team.teamId === currentTeamId} />)}
                 <div className="phase-card">
-                  <div className="team-stat-title">Current round</div>
+                  <div className="team-stat-title">Round state</div>
                   <div className="phase-name">Hand {round.handNumber} · Deal {round.activeDeal}</div>
                   <div className="phase-turn">Turn: {game.players[round.turnPlayerId]?.name}</div>
                 </div>
               </div>
+              <TurnBanner
+                game={game}
+                round={round}
+                currentPlayerId={playerId}
+                activeCard={activeCard}
+                movesForActiveCard={movesForActiveCard}
+                moveOutcomes={moveOutcomes}
+                lastPlayedCardId={lastPlayedCardId}
+                boardCardsById={boardCardsById}
+              />
               <Board
                 cards={round.board}
                 deckRemaining={round.deckRemaining}
                 canLimpia={canLimpia}
-                highlightedCaptureIds={previewedMove?.captureIds || []}
+                highlightedCaptureIds={highlightedCaptureIds}
+                highlightedTargetIds={highlightedTargetIds}
+                captureOrderMap={captureOrderMap}
                 directDropMoves={directDropMoves}
                 trailMove={trailMove}
                 dragCardId={dragCardId}
                 onPlay={playChosenMove}
+                lastPlayedCardId={lastPlayedCardId}
+                previewedMove={previewedMove}
+                previewCopy={previewCopy}
               />
               <MovePicker
                 hand={visibleHand}
@@ -705,12 +1006,13 @@ export default function App() {
                 boardCardsById={boardCardsById}
                 onPlay={playChosenMove}
                 isYourTurn={isYourTurn}
-                selectedCardId={selectedCardId}
+                activeCardId={activeCardId}
                 setSelectedCardId={setSelectedCardId}
                 dragCardId={dragCardId}
                 setDragCardId={setDragCardId}
                 previewMoveKey={previewMoveKey}
                 setPreviewMoveKey={setPreviewMoveKey}
+                moveOutcomes={moveOutcomes}
               />
               {game.status === 'finished' ? <section className="notice-card">Game over — Team {game.winner} wins.</section> : null}
             </section>

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,28 +1,70 @@
 import { initializeApp } from 'firebase/app';
-import { getDatabase } from 'firebase/database';
+import { connectDatabaseEmulator, getDatabase } from 'firebase/database';
 
-const fallbackConfig = {
-  apiKey: 'AIzaSyAnvPUD8NmYUC-fA7ypMvlrfIdAngL0KF0',
-  authDomain: 'cuarenta-dfbf1.firebaseapp.com',
-  databaseURL: 'https://cuarenta-dfbf1-default-rtdb.firebaseio.com',
-  projectId: 'cuarenta-dfbf1',
-  storageBucket: 'cuarenta-dfbf1.firebasestorage.app',
-  messagingSenderId: '78708075147',
-  appId: '1:78708075147:web:3bffd7a9a76f0ed27fc28e',
-  measurementId: 'G-QE2JKLQ686',
+function clean(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+const liveConfig = {
+  apiKey: clean(import.meta.env.VITE_FIREBASE_API_KEY),
+  authDomain: clean(import.meta.env.VITE_FIREBASE_AUTH_DOMAIN),
+  databaseURL: clean(import.meta.env.VITE_FIREBASE_DATABASE_URL),
+  projectId: clean(import.meta.env.VITE_FIREBASE_PROJECT_ID),
+  storageBucket: clean(import.meta.env.VITE_FIREBASE_STORAGE_BUCKET),
+  messagingSenderId: clean(import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID),
+  appId: clean(import.meta.env.VITE_FIREBASE_APP_ID),
+  measurementId: clean(import.meta.env.VITE_FIREBASE_MEASUREMENT_ID),
 };
 
-const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || fallbackConfig.apiKey,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || fallbackConfig.authDomain,
-  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL || fallbackConfig.databaseURL,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || fallbackConfig.projectId,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || fallbackConfig.storageBucket,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || fallbackConfig.messagingSenderId,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID || fallbackConfig.appId,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || fallbackConfig.measurementId,
-};
+const requiredLiveFields = [
+  'apiKey',
+  'authDomain',
+  'databaseURL',
+  'projectId',
+  'storageBucket',
+  'messagingSenderId',
+  'appId',
+];
 
-const app = initializeApp(firebaseConfig);
-export const db = getDatabase(app);
-export const databaseUrl = firebaseConfig.databaseURL;
+const missingLiveFields = requiredLiveFields.filter((field) => !liveConfig[field]);
+const useEmulator = import.meta.env.VITE_USE_FIREBASE_EMULATOR === 'true';
+const emulatorHost = clean(import.meta.env.VITE_FIREBASE_EMULATOR_HOST) || '127.0.0.1';
+const emulatorPort = Number(import.meta.env.VITE_FIREBASE_EMULATOR_PORT || 9000);
+
+let app = null;
+let db = null;
+let databaseUrl = '';
+let firebaseMode = 'unconfigured';
+let firebaseConfigError = '';
+
+if (useEmulator) {
+  const projectId = liveConfig.projectId || 'cuarenta-local';
+  app = initializeApp({
+    apiKey: liveConfig.apiKey || 'demo-api-key',
+    authDomain: liveConfig.authDomain || `${projectId}.local`,
+    databaseURL: liveConfig.databaseURL || `http://${emulatorHost}:${emulatorPort}?ns=${projectId}-default-rtdb`,
+    projectId,
+    storageBucket: liveConfig.storageBucket || `${projectId}.appspot.com`,
+    messagingSenderId: liveConfig.messagingSenderId || '000000000000',
+    appId: liveConfig.appId || `1:000000000000:web:${projectId}`,
+    measurementId: liveConfig.measurementId || undefined,
+  });
+  db = getDatabase(app);
+  try {
+    connectDatabaseEmulator(db, emulatorHost, emulatorPort);
+  } catch {
+    // Vite HMR can re-run this module after the database instance is already connected.
+  }
+  databaseUrl = `http://${emulatorHost}:${emulatorPort}?ns=${projectId}-default-rtdb`;
+  firebaseMode = 'emulator';
+} else if (!missingLiveFields.length) {
+  app = initializeApp(liveConfig);
+  db = getDatabase(app);
+  databaseUrl = liveConfig.databaseURL;
+  firebaseMode = 'live';
+} else {
+  firebaseConfigError = `Firebase is not configured. Copy .env.example and either point the app at the RTDB emulator or provide the VITE_FIREBASE_* web config for a project. Missing: ${missingLiveFields.join(', ')}`;
+}
+
+export { app, db, databaseUrl, firebaseConfigError, firebaseMode };
+export const hasFirebase = Boolean(db);

--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -44,6 +44,14 @@ function rotateOrder(playerIds, dealerIndex) {
   return [...playerIds.slice(start), ...playerIds.slice(0, start)];
 }
 
+export function getDealerPlayerId(round, seating = []) {
+  if (round?.dealerPlayerId) return round.dealerPlayerId;
+  if (typeof round?.dealerIndex === 'number' && round.dealerIndex >= 0) {
+    return seating[round.dealerIndex] || null;
+  }
+  return Array.isArray(round?.turnOrder) && round.turnOrder.length ? round.turnOrder[round.turnOrder.length - 1] : null;
+}
+
 function countRanks(cards) {
   const counts = {};
   for (const card of cards) counts[card.rank] = (counts[card.rank] || 0) + 1;
@@ -165,6 +173,7 @@ function buildRound(players, dealerIndex, scores, handNumber = 1) {
   const hands = {};
   const capturePiles = { A: [], B: [] };
   const roundOrder = rotateOrder(seating, dealerIndex);
+  const dealerPlayerId = seating[dealerIndex];
 
   for (const playerId of seating) hands[playerId] = [];
   for (let deal = 0; deal < 2; deal += 1) {
@@ -178,6 +187,7 @@ function buildRound(players, dealerIndex, scores, handNumber = 1) {
   const round = {
     handNumber,
     dealerIndex,
+    dealerPlayerId,
     turnOrder: roundOrder,
     turnPlayerId: roundOrder[0],
     activeDeal: 1,
@@ -285,6 +295,7 @@ export function getLegalMoves(round, playerId) {
     if (NUMERIC_RANKS.has(card.rank)) {
       const additions = subsetCaptures(board, card.value);
       for (const set of additions) {
+        if (set.length === 1 && set[0].rank === card.rank) continue;
         const captured = applySequence(board, set, card);
         const text = set.map((c) => `${c.rank}${c.suit}`).join(' + ');
         moves.push({
@@ -316,12 +327,66 @@ function summarizeCard(card) {
   return `${card.rank}${card.suit}`;
 }
 
+function matchingMove(candidate, move) {
+  return candidate.type === move.type
+    && candidate.playedCardId === move.playedCardId
+    && JSON.stringify(candidate.captureIds || []) === JSON.stringify(move.captureIds || []);
+}
+
+export function analyzeMove(game, playerId, move) {
+  if (!game?.round || !move) {
+    return {
+      move: null,
+      captureCount: 0,
+      sequenceCount: 0,
+      isCaida: false,
+      isLimpia: false,
+      bonusPoints: 0,
+    };
+  }
+
+  const round = game.round;
+  const selected = getLegalMoves(round, playerId).find((candidate) => matchingMove(candidate, move));
+  if (!selected) {
+    return {
+      move: null,
+      captureCount: 0,
+      sequenceCount: 0,
+      isCaida: false,
+      isLimpia: false,
+      bonusPoints: 0,
+    };
+  }
+
+  const captureSet = new Set(selected.captureIds || []);
+  const targetCount = (selected.targetIds || []).length;
+  const teamId = round.teamsByPlayer?.[playerId]?.teamId;
+  const scoreBefore = game.scores?.[teamId] || 0;
+  const remainingBoardCards = (round.board || []).filter((card) => !captureSet.has(card.id)).length;
+  const isCaida = selected.type === 'match'
+    && Boolean(round.lastPlayedCard)
+    && selected.targetIds?.[0] === round.lastPlayedCard.cardId
+    && round.lastPlayedCard.dealNumber === round.activeDeal
+    && round.lastPlayedCard.turnNumber === round.playsInCurrentDeal;
+  const isLimpia = selected.type !== 'trail' && remainingBoardCards === 0 && scoreBefore < 38;
+
+  return {
+    move: selected,
+    captureCount: captureSet.size,
+    sequenceCount: Math.max(0, captureSet.size - targetCount),
+    isCaida,
+    isLimpia,
+    bonusPoints: (isCaida ? 2 : 0) + (isLimpia ? 2 : 0),
+  };
+}
+
 function finalizeHand(game, lastActorId) {
   const round = game.round;
   const pointsByCards = { A: 0, B: 0 };
   const a = round.capturedCardCount.A;
   const b = round.capturedCardCount.B;
-  const dealerTeam = round.teamsByPlayer[round.turnOrder[round.dealerIndex]]?.teamId || 'A';
+  const dealerPlayerId = getDealerPlayerId(round, game.seating);
+  const dealerTeam = dealerPlayerId ? (round.teamsByPlayer[dealerPlayerId]?.teamId || 'A') : 'A';
   const nonDealerTeam = dealerTeam === 'A' ? 'B' : 'A';
   const now = Date.now();
 
@@ -397,10 +462,8 @@ export function applyMove(game, playerId, move) {
   round.events = Array.isArray(round.events) ? round.events : [];
   if (round.turnPlayerId !== playerId) throw new Error('Not your turn.');
 
-  const legalMoves = getLegalMoves(round, playerId);
-  const selected = legalMoves.find((candidate) =>
-    candidate.type === move.type && candidate.playedCardId === move.playedCardId && JSON.stringify(candidate.captureIds || []) === JSON.stringify(move.captureIds || [])
-  );
+  const analysis = analyzeMove({ ...game, round }, playerId, move);
+  const selected = analysis.move;
   if (!selected) throw new Error('Illegal move.');
 
   const hand = round.hands[playerId];
@@ -422,15 +485,8 @@ export function applyMove(game, playerId, move) {
     round.capturePiles[teamId].push(playedCard, ...capturedCards);
     round.capturedCardCount[teamId] += capturedCards.length + 1;
 
-    const isCaida = selected.type === 'match'
-      && round.lastPlayedCard
-      && selected.targetIds?.[0] === round.lastPlayedCard.cardId
-      && round.lastPlayedCard.dealNumber === round.activeDeal
-      && round.lastPlayedCard.turnNumber === round.playsInCurrentDeal;
-    if (isCaida) pointsEarned += 2;
-
-    const wouldBeLimpia = round.board.length === 0;
-    if (wouldBeLimpia && game.scores[teamId] < 38) pointsEarned += 2;
+    if (analysis.isCaida) pointsEarned += 2;
+    if (analysis.isLimpia) pointsEarned += 2;
 
     round.scores[teamId] += pointsEarned;
     round.lastPlayedCard = null;

--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -229,7 +229,8 @@ function applyDealAnnouncements(round, dealNumber, players) {
 
 export function startMatchFromLobby(game) {
   const players = game.seating.map((playerId) => game.players[playerId]);
-  const round = buildRound(players, 0, { A: 0, B: 0 }, 1);
+  const dealerIndex = Math.floor(Math.random() * players.length);
+  const round = buildRound(players, dealerIndex, { A: 0, B: 0 }, 1);
   const now = Date.now();
   const nextGame = {
     ...game,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -128,8 +128,6 @@ button:disabled {
 .board-shell,
 .profile-card,
 .activity-card,
-.team-stat,
-.phase-card,
 .hand-shell,
 .lobby-seat,
 .resume-card,
@@ -492,18 +490,21 @@ button:focus-visible {
   max-width: 1460px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 250px minmax(0, 1fr) 280px;
-  gap: 18px;
+  grid-template-columns: 265px minmax(0, 1fr) 270px;
+  gap: 16px;
+  align-items: start;
 }
 
-.sidebar-panel,
+.sidebar-column,
 .activity-column {
+  display: grid;
+  gap: 16px;
   align-self: start;
 }
 
 .sidebar-panel {
   border-radius: 28px;
-  padding: 22px;
+  padding: 20px;
 }
 
 .sidebar-title,
@@ -511,6 +512,93 @@ button:focus-visible {
   margin: 10px 0 0;
   font-family: 'Noto Serif', serif;
   color: var(--primary-deep);
+}
+
+.score-sidebar {
+  display: grid;
+  gap: 16px;
+}
+
+.sidebar-scorecards {
+  display: grid;
+  gap: 12px;
+}
+
+.side-team-card {
+  border-radius: 20px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(94, 61, 47, 0.08);
+}
+
+.side-team-card.current-team {
+  border-color: rgba(140, 79, 54, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(140, 79, 54, 0.08);
+}
+
+.side-team-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: end;
+}
+
+.side-team-label {
+  color: var(--primary);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.side-team-score {
+  font-family: 'Noto Serif', serif;
+  font-size: 28px;
+  line-height: 0.9;
+  color: var(--primary-deep);
+}
+
+.side-team-score small {
+  margin-left: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.side-team-players {
+  margin-top: 8px;
+  font-weight: 800;
+}
+
+.side-team-meta {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.round-brief {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.round-brief div {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(140, 79, 54, 0.07);
+}
+
+.round-brief span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.round-brief strong {
+  color: var(--primary-deep);
+  font-size: 14px;
 }
 
 .timeline {
@@ -609,17 +697,9 @@ button:focus-visible {
 
 .center-column {
   display: grid;
-  gap: 18px;
+  gap: 16px;
 }
 
-.team-stats-row {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.team-stat,
-.phase-card,
 .turn-banner,
 .hand-shell,
 .profile-card,
@@ -628,68 +708,12 @@ button:focus-visible {
   padding: 18px;
 }
 
-.team-stat.current-team {
-  border-color: rgba(140, 79, 54, 0.28);
-}
-
-.team-stat-head {
+.turn-banner {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  align-items: start;
-}
-
-.team-stat-players {
-  margin-top: 6px;
-  font-weight: 800;
-}
-
-.team-score-stack {
-  display: grid;
-  justify-items: end;
-  color: var(--primary-deep);
-}
-
-.team-score-stack strong {
-  font-family: 'Noto Serif', serif;
-  font-size: 34px;
-  line-height: 0.9;
-}
-
-.team-score-stack span {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.team-progress {
-  margin-top: 14px;
-  height: 8px;
-  border-radius: 999px;
-  background: rgba(140, 79, 54, 0.08);
-  overflow: hidden;
-}
-
-.team-progress-fill {
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, #c7a14a 0%, var(--primary) 100%);
-}
-
-.team-stat-line,
-.phase-name,
-.phase-turn {
-  margin-top: 10px;
-  color: var(--muted);
-}
-
-.phase-name {
-  color: var(--text);
-  font-weight: 800;
-}
-
-.turn-banner {
-  display: grid;
-  gap: 14px;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
   background: linear-gradient(180deg, rgba(255, 250, 244, 0.96) 0%, rgba(248, 238, 228, 0.94) 100%);
 }
 
@@ -697,24 +721,30 @@ button:focus-visible {
   border-color: rgba(180, 141, 59, 0.28);
 }
 
+.turn-banner-copy {
+  min-width: 0;
+}
+
 .turn-banner h2 {
-  margin: 6px 0 0;
+  margin: 4px 0 0;
   font-family: 'Noto Serif', serif;
-  font-size: clamp(24px, 3vw, 32px);
+  font-size: clamp(20px, 2.3vw, 28px);
   line-height: 1.08;
   color: var(--primary-deep);
 }
 
 .turn-banner p {
-  margin: 10px 0 0;
+  margin: 6px 0 0;
   color: var(--muted);
-  line-height: 1.55;
+  line-height: 1.45;
+  font-size: 14px;
 }
 
 .turn-banner-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .turn-chip.warning {
@@ -733,8 +763,8 @@ button:focus-visible {
   --preview-solid: rgba(255, 244, 216, 0.92);
   position: relative;
   border-radius: 36px;
-  min-height: 470px;
-  padding: 74px 26px 84px;
+  min-height: 430px;
+  padding: 58px 22px 78px;
   background:
     radial-gradient(circle at 20% 14%, rgba(255, 244, 216, 0.12), transparent 24%),
     linear-gradient(180deg, rgba(55, 94, 79, 0.95) 0%, var(--felt) 100%);
@@ -784,7 +814,7 @@ button:focus-visible {
 
 .board-hud {
   position: absolute;
-  top: 16px;
+  top: 14px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -795,7 +825,7 @@ button:focus-visible {
 }
 
 .hud-chip {
-  padding: 9px 14px;
+  padding: 8px 12px;
   border-radius: 999px;
   background: rgba(250, 242, 227, 0.96);
   border: 1px solid rgba(255, 244, 216, 0.1);
@@ -1260,6 +1290,31 @@ button:focus-visible {
   gap: 16px;
 }
 
+.utility-card {
+  display: grid;
+  gap: 12px;
+}
+
+.utility-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.utility-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.utility-button {
+  padding: 10px 14px;
+  border-radius: 14px;
+}
+
 .profile-card {
   text-align: center;
 }
@@ -1343,18 +1398,35 @@ button:focus-visible {
     grid-template-columns: 1fr;
   }
 
+  .center-column {
+    order: 1;
+  }
+
+  .sidebar-column {
+    order: 2;
+  }
+
   .activity-column {
+    order: 3;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 860px) {
-  .team-stats-row,
   .activity-column,
   .lobby-grid,
   .join-inline,
-  .resume-card {
+  .resume-card,
+  .round-brief {
     grid-template-columns: 1fr;
+  }
+
+  .turn-banner {
+    display: grid;
+  }
+
+  .turn-banner-chips {
+    justify-content: flex-start;
   }
 
   .resume-card {
@@ -1394,8 +1466,8 @@ button:focus-visible {
   }
 
   .board-shell {
-    padding: 86px 14px 92px;
-    min-height: 380px;
+    padding: 72px 14px 88px;
+    min-height: 360px;
   }
 
   .board-preview {
@@ -1423,7 +1495,12 @@ button:focus-visible {
     grid-template-columns: 1fr;
   }
 
-  .profile-stats {
+  .profile-stats,
+  .utility-row {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .utility-row {
+    display: grid;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,193 +1,387 @@
 :root {
   color-scheme: light;
-  --bg: #f5eee4;
-  --surface: #fbf9f5;
-  --surface-low: rgba(250, 243, 233, 0.86);
-  --surface-border: rgba(164, 93, 65, 0.12);
-  --text: #1b1c1a;
-  --muted: #6f5d55;
-  --primary: #a45d41;
-  --primary-dark: #86452b;
-  --accent: #c9a348;
-  --shadow: 0 14px 28px rgba(98, 63, 48, 0.12);
+  --bg: #f2eadf;
+  --bg-warm: #e8dccd;
+  --surface: rgba(255, 251, 246, 0.88);
+  --surface-strong: rgba(255, 249, 242, 0.94);
+  --surface-border: rgba(94, 61, 47, 0.12);
+  --text: #201815;
+  --muted: #6f6057;
+  --primary: #8c4f36;
+  --primary-deep: #6f3723;
+  --accent: #b48d3b;
+  --felt: #305548;
+  --felt-deep: #224035;
+  --felt-line: rgba(255, 244, 216, 0.18);
+  --good: #245b43;
+  --danger: #7a232b;
+  --shadow: 0 22px 48px rgba(67, 40, 26, 0.12);
+  --shadow-soft: 0 12px 24px rgba(67, 40, 26, 0.08);
 }
 
-* { box-sizing: border-box; }
-html, body, #root { min-height: 100%; }
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
   color: var(--text);
   font-family: Manrope, system-ui, sans-serif;
   background:
-    linear-gradient(rgba(164, 93, 65, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(164, 93, 65, 0.03) 1px, transparent 1px),
-    radial-gradient(circle at top, rgba(164, 93, 65, 0.10), transparent 35%),
-    var(--bg);
-  background-size: 20px 20px, 20px 20px, auto, auto;
+    radial-gradient(circle at top left, rgba(180, 141, 59, 0.12), transparent 28%),
+    linear-gradient(rgba(111, 55, 35, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(111, 55, 35, 0.04) 1px, transparent 1px),
+    linear-gradient(180deg, #f7f1e7 0%, var(--bg) 100%);
+  background-size: auto, 22px 22px, 22px 22px, auto;
 }
-button, input, select { font: inherit; }
-button { cursor: pointer; }
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
 
 .cuarenta-app {
   min-height: 100vh;
-  padding: 84px 18px 24px;
+  padding: 92px 18px 28px;
 }
 
 .topbar {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 64px;
+  inset: 0 0 auto;
+  height: 68px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   padding: 0 24px;
-  background: rgba(245, 238, 228, 0.92);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--surface-border);
-  z-index: 10;
+  background: rgba(246, 238, 227, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(94, 61, 47, 0.08);
+  z-index: 20;
 }
 
-.brand-block { display: flex; align-items: center; gap: 28px; }
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
 .brand {
   font-family: 'Noto Serif', serif;
-  font-size: 30px;
+  font-size: 32px;
   font-weight: 700;
-  color: var(--primary-dark);
+  color: var(--primary-deep);
+  letter-spacing: -0.02em;
 }
-.topnav { display: flex; gap: 18px; color: var(--muted); }
-.topnav span:first-child { color: var(--primary-dark); text-decoration: underline; text-underline-offset: 6px; }
-.topbar-actions { display: flex; align-items: center; gap: 10px; }
-.header-button, .share-pill, .notice-card, .auth-card, .sidebar-panel, .board-shell, .profile-card, .activity-card, .team-stat, .phase-card, .hand-shell, .lobby-seat, .resume-card {
-  background: var(--surface-low);
-  backdrop-filter: blur(10px);
+
+.topnav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.topnav button {
+  border: none;
+  background: transparent;
+  padding: 8px 10px;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.topnav button.active,
+.topnav button:hover {
+  color: var(--primary-deep);
+  background: rgba(140, 79, 54, 0.1);
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.header-button,
+.share-pill,
+.notice-card,
+.auth-card,
+.sidebar-panel,
+.board-shell,
+.profile-card,
+.activity-card,
+.team-stat,
+.phase-card,
+.hand-shell,
+.lobby-seat,
+.resume-card,
+.turn-banner,
+.reference-drawer {
+  background: var(--surface);
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
 }
-.header-button, .share-pill, .secondary-chip {
-  border-radius: 12px;
+
+.header-button,
+.share-pill,
+.secondary-chip {
+  border-radius: 14px;
   padding: 10px 14px;
   font-size: 13px;
+  font-weight: 700;
 }
-.header-button {
-  background: var(--primary);
-  color: white;
-  border: none;
-}
-.secondary-chip {
-  background: rgba(164, 93, 65, 0.10);
-  color: var(--primary-dark);
-  border: 1px solid rgba(134, 69, 43, 0.14);
-}
-.share-pill strong { color: var(--primary-dark); }
 
-.invite-copy { text-align: center; max-width: 700px; margin: 0 auto; }
-.invite-copy.centered { margin-bottom: 24px; }
-.eyebrow {
+.header-button {
+  border: none;
+  background: linear-gradient(180deg, #a75f43 0%, var(--primary) 100%);
+  color: white;
+}
+
+.secondary-chip {
+  border: 1px solid rgba(94, 61, 47, 0.1);
+  background: rgba(140, 79, 54, 0.08);
+  color: var(--primary-deep);
+}
+
+.share-pill strong {
+  color: var(--primary-deep);
+}
+
+.reference-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(33, 24, 20, 0.28);
+  display: grid;
+  place-items: center;
+  z-index: 30;
+  padding: 24px;
+}
+
+.reference-drawer {
+  width: min(720px, calc(100vw - 32px));
+  border-radius: 28px;
+  padding: 24px;
+  background: rgba(252, 247, 240, 0.98);
+}
+
+.reference-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.reference-head h2 {
+  margin: 8px 0 0;
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(28px, 4vw, 40px);
+  line-height: 1.05;
+  color: var(--primary-deep);
+}
+
+.reference-tabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+
+.reference-tab {
+  border: 1px solid rgba(94, 61, 47, 0.1);
+  background: rgba(140, 79, 54, 0.06);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.1em;
+  font-size: 12px;
+}
+
+.reference-tab.active {
+  background: rgba(140, 79, 54, 0.14);
+  color: var(--primary-deep);
+}
+
+.reference-lead {
+  margin: 18px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.reference-list {
+  margin: 18px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+  line-height: 1.55;
+}
+
+.reference-footer {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(94, 61, 47, 0.1);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.section-kicker,
+.eyebrow,
+.team-stat-title,
+.timeline-kicker,
+.hand-head,
+.move-kind,
+.profile-sub,
+.lobby-footnote {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
   font-size: 11px;
-  color: var(--primary);
   font-weight: 800;
 }
-.invite-copy h1 {
-  margin: 8px 0 10px;
-  font-family: 'Noto Serif', serif;
-  font-size: clamp(42px, 7vw, 78px);
-  line-height: 1;
+
+.section-kicker,
+.eyebrow,
+.team-stat-title,
+.timeline-kicker,
+.hand-head,
+.move-kind,
+.lobby-footnote {
   color: var(--primary);
 }
-.invite-copy p { margin: 0; color: var(--muted); }
+
+.invite-copy {
+  text-align: center;
+  max-width: 740px;
+  margin: 0 auto;
+}
+
+.invite-copy.centered {
+  margin-bottom: 12px;
+}
+
+.invite-copy h1 {
+  margin: 10px 0 12px;
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(42px, 7vw, 78px);
+  line-height: 0.95;
+  color: var(--primary-deep);
+}
+
+.invite-copy p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
 
 .lobby-shell {
-  max-width: 980px;
-  margin: 18px auto 0;
+  max-width: 1040px;
+  margin: 20px auto 0;
   display: grid;
   gap: 26px;
 }
-.lobby-shell.invite-mode { padding-top: 48px; }
+
+.lobby-shell.invite-mode {
+  padding-top: 36px;
+}
+
 .auth-card {
-  max-width: 520px;
+  max-width: 560px;
   margin: 0 auto;
   width: 100%;
-  border-radius: 24px;
+  border-radius: 26px;
   padding: 22px;
   display: grid;
   gap: 16px;
 }
-label { display: grid; gap: 8px; color: var(--muted); font-size: 14px; }
-input, select {
+
+label {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+input,
+select {
   width: 100%;
-  padding: 13px 15px;
+  padding: 14px 16px;
   border-radius: 14px;
-  border: 1px solid rgba(134, 69, 43, 0.16);
-  background: rgba(255,255,255,0.8);
+  border: 1px solid rgba(94, 61, 47, 0.12);
+  background: rgba(255, 255, 255, 0.76);
   color: var(--text);
 }
-.button-stack, .join-inline, .play-controls { display: grid; gap: 12px; }
-.join-inline { grid-template-columns: 1fr auto; }
-.primary-button, .secondary-button {
+
+input:focus,
+select:focus,
+button:focus-visible {
+  outline: 2px solid rgba(140, 79, 54, 0.22);
+  outline-offset: 2px;
+}
+
+.button-stack,
+.join-inline,
+.play-controls {
+  display: grid;
+  gap: 12px;
+}
+
+.join-inline {
+  grid-template-columns: 1fr auto;
+}
+
+.primary-button,
+.secondary-button,
+.text-button {
   padding: 14px 18px;
   border-radius: 16px;
-  border: 1px solid transparent;
   font-weight: 800;
-  letter-spacing: 0.04em;
 }
-.primary-button { background: var(--primary); color: white; }
-.secondary-button { background: rgba(164, 93, 65, 0.12); color: var(--primary-dark); }
-.primary-button.wide { min-width: 280px; }
-button:disabled { opacity: 0.55; cursor: not-allowed; }
 
-.lobby-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-  max-width: 780px;
-  margin: 0 auto;
-}
-.lobby-seat {
-  border-radius: 20px;
-  padding: 18px;
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  position: relative;
-}
-.lobby-seat.current { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(164, 93, 65, 0.18), var(--shadow); }
-.lobby-seat.empty { opacity: 0.72; border-style: dashed; }
-.avatar-orb {
-  width: 54px;
-  height: 54px;
-  border-radius: 18px;
-  display: grid;
-  place-items: center;
-  font-weight: 800;
-  background: rgba(164, 93, 65, 0.14);
-  color: var(--primary-dark);
-}
-.seat-copy { display: grid; gap: 4px; }
-.seat-name { font-weight: 800; color: var(--primary-dark); }
-.seat-status { font-size: 13px; color: var(--muted); }
-.host-badge {
-  position: absolute;
-  right: 14px;
-  top: 14px;
-  font-size: 11px;
-  font-weight: 800;
+.primary-button {
+  border: none;
   color: white;
-  background: var(--primary);
-  border-radius: 999px;
-  padding: 4px 8px;
+  background: linear-gradient(180deg, #a85f42 0%, var(--primary) 100%);
 }
-.lobby-actions { display: grid; justify-items: center; gap: 10px; }
-.lobby-footnote { font-size: 12px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--primary); font-weight: 700; }
+
+.secondary-button {
+  border: 1px solid rgba(94, 61, 47, 0.1);
+  background: rgba(140, 79, 54, 0.08);
+  color: var(--primary-deep);
+}
+
+.text-button {
+  border: none;
+  background: transparent;
+  color: var(--primary-deep);
+}
+
+.primary-button.wide {
+  min-width: 280px;
+}
 
 .notice-card {
-  max-width: 980px;
+  max-width: 1040px;
   margin: 14px auto;
+  border-radius: 20px;
   padding: 16px 18px;
-  border-radius: 18px;
   color: var(--muted);
   overflow-wrap: anywhere;
 }
@@ -197,277 +391,77 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   font-size: 13px;
 }
 
-.game-layout {
-  max-width: 1380px;
-  margin: 0 auto;
+.lobby-grid {
   display: grid;
-  grid-template-columns: 250px minmax(0, 1fr) 270px;
-  gap: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
 }
-.sidebar-panel, .activity-column { align-self: start; }
-.sidebar-panel {
-  border-radius: 24px;
-  padding: 20px;
-}
-.sidebar-title {
-  margin: 0 0 20px;
-  font-family: 'Noto Serif', serif;
-  color: var(--primary);
-}
-.timeline { position: relative; display: grid; gap: 16px; }
-.timeline::before {
-  content: '';
-  position: absolute;
-  left: 11px;
-  top: 10px;
-  bottom: 10px;
-  width: 1px;
-  background: rgba(164, 93, 65, 0.24);
-}
-.timeline-item {
-  position: relative;
-  padding-left: 28px;
-  opacity: 0.7;
-}
-.timeline-item.active { opacity: 1; }
-.timeline-dot {
-  position: absolute;
-  left: 6px;
-  top: 8px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #d0c2ba;
-}
-.timeline-item.active .timeline-dot { background: var(--primary); box-shadow: 0 0 0 6px rgba(164, 93, 65, 0.14); }
-.timeline-kicker { font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--primary); font-weight: 800; }
-.timeline-row { display: flex; justify-content: space-between; gap: 10px; align-items: end; }
-.timeline-name { font-weight: 800; }
-.timeline-score { font-family: 'Noto Serif', serif; font-weight: 700; color: var(--primary-dark); }
-.timeline-score small { font-size: 11px; color: var(--muted); }
 
-.center-column { display: grid; gap: 18px; }
-.team-stats-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
-.team-stat, .phase-card {
+.lobby-seat {
   border-radius: 22px;
   padding: 18px;
-}
-.team-stat-title {
-  color: var(--primary);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 11px;
-  font-weight: 800;
-}
-.team-stat-players { margin-top: 6px; font-weight: 800; }
-.team-stat-line, .phase-name, .phase-turn { margin-top: 8px; color: var(--muted); }
-.phase-name { color: var(--text); font-weight: 800; }
-
-.board-shell {
+  display: flex;
+  align-items: center;
+  gap: 14px;
   position: relative;
-  border-radius: 40px;
-  min-height: 420px;
-  padding: 64px 24px 24px;
-  background: rgba(164, 93, 65, 0.05);
-  border: 2px solid rgba(164, 93, 65, 0.10);
-  box-shadow: inset 0 0 40px rgba(164, 93, 65, 0.05);
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
-.board-shell-armed {
-  border-color: rgba(164, 93, 65, 0.28);
-  box-shadow: inset 0 0 0 2px rgba(164, 93, 65, 0.12), inset 0 0 40px rgba(164, 93, 65, 0.08);
-}
-.board-hud {
-  position: absolute;
-  left: 50%;
-  top: 16px;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-.hud-chip {
-  padding: 9px 14px;
-  border-radius: 999px;
-  background: rgba(250, 243, 233, 0.96);
-  border: 1px solid var(--surface-border);
-  font-size: 12px;
-  font-weight: 800;
-}
-.hud-chip.accent { color: #7d6200; }
-.table-grid {
-  min-height: 320px;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
-  gap: 16px;
-  align-items: center;
-  justify-items: center;
-  border-radius: 28px;
-  transition: background 160ms ease, box-shadow 160ms ease;
-}
-.table-grid.is-drop-target {
-  background: rgba(164, 93, 65, 0.08);
-  box-shadow: inset 0 0 0 2px rgba(164, 93, 65, 0.18);
-}
-.empty-table { color: var(--muted); }
-.stitch-card {
-  width: 84px;
-  min-height: 126px;
-  border-radius: 16px;
-  border: 1px solid rgba(134, 69, 43, 0.14);
-  background: rgba(255, 251, 245, 0.95);
-  box-shadow: 0 10px 20px rgba(80, 50, 40, 0.10);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: stretch;
-  padding: 10px;
-  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease, background 140ms ease;
-}
-.stitch-card.is-red { color: var(--primary); }
-.stitch-card.is-dark { color: #23201d; }
-.card-corner { font-family: 'Noto Serif', serif; font-weight: 700; font-size: 22px; }
-.card-corner.bottom { align-self: flex-end; transform: rotate(180deg); }
-.card-center { display: grid; place-items: center; font-size: 28px; }
-.hand-shell {
-  border-radius: 26px;
-  padding: 18px;
-}
-.hand-head {
-  display: flex;
-  justify-content: space-between;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--primary);
-  font-weight: 800;
-  margin-bottom: 12px;
-}
-.hand-kicker { color: rgba(164, 93, 65, 0.6); }
-.stitch-hand-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
-  gap: 12px;
-}
-.hand-card.selected { outline: 2px solid rgba(164, 93, 65, 0.35); transform: translateY(-4px); }
-.hand-card.dragging { transform: translateY(-10px) rotate(-2deg); box-shadow: 0 18px 30px rgba(80, 50, 40, 0.16); }
-.board-card.is-click-target { cursor: pointer; }
-.board-card.is-highlighted { transform: translateY(-6px); box-shadow: 0 18px 30px rgba(80, 50, 40, 0.16); border-color: rgba(164, 93, 65, 0.38); }
-.board-card.is-direct-target { box-shadow: 0 0 0 3px rgba(164, 93, 65, 0.18), 0 18px 30px rgba(80, 50, 40, 0.16); }
-.play-controls { margin-top: 16px; display: grid; gap: 14px; }
-.move-options-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 12px;
-}
-.move-option {
-  text-align: left;
-  padding: 14px;
-  border-radius: 18px;
-  border: 1px solid rgba(134, 69, 43, 0.14);
-  background: rgba(255,255,255,0.78);
-  display: grid;
-  gap: 10px;
-}
-.move-option.previewed,
-.move-option.drop-ready {
-  border-color: rgba(164, 93, 65, 0.32);
-  box-shadow: 0 14px 24px rgba(80, 50, 40, 0.12);
-  transform: translateY(-2px);
-}
-.move-option-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  align-items: center;
-}
-.move-kind {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-weight: 800;
-  color: var(--primary);
-}
-.move-kicker {
-  font-size: 12px;
-  color: var(--muted);
-}
-.move-capture-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-.mini-card {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 48px;
-  padding: 8px 10px;
-  border-radius: 12px;
-  background: rgba(245, 238, 228, 0.95);
-  border: 1px solid rgba(134, 69, 43, 0.12);
-  font-weight: 800;
-}
-.move-empty-target {
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: rgba(164, 93, 65, 0.08);
-  color: var(--primary-dark);
-  font-weight: 700;
-}
-.move-label {
-  font-size: 13px;
-  color: var(--muted);
-  line-height: 1.45;
-}
-.ghost-note {
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.45;
-}
-.muted-note { margin-top: 12px; color: var(--muted); }
 
-.activity-column { display: grid; gap: 16px; }
-.profile-card, .activity-card {
-  border-radius: 24px;
-  padding: 18px;
+.lobby-seat.current {
+  border-color: rgba(140, 79, 54, 0.4);
+  box-shadow: 0 0 0 2px rgba(140, 79, 54, 0.12), var(--shadow);
 }
-.profile-card { text-align: center; }
-.profile-avatar {
-  width: 68px;
-  height: 68px;
+
+.lobby-seat.empty {
+  opacity: 0.72;
+  border-style: dashed;
+}
+
+.avatar-orb {
+  width: 56px;
+  height: 56px;
   border-radius: 20px;
   display: grid;
   place-items: center;
-  margin: 0 auto 10px;
-  background: rgba(164, 93, 65, 0.12);
-  color: var(--primary-dark);
   font-weight: 800;
-  font-size: 28px;
+  background: rgba(140, 79, 54, 0.1);
+  color: var(--primary-deep);
 }
-.profile-name { font-weight: 800; font-size: 20px; }
-.profile-sub { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; margin-top: 4px; }
-.profile-stats {
-  margin-top: 16px;
+
+.seat-copy {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+}
+
+.seat-name {
+  font-weight: 800;
+  color: var(--primary-deep);
+}
+
+.seat-status {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.host-badge {
+  position: absolute;
+  right: 14px;
+  top: 14px;
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: var(--primary);
+  color: white;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.lobby-actions {
+  display: grid;
+  justify-items: center;
   gap: 10px;
 }
-.profile-stats div {
-  padding: 12px;
-  border-radius: 16px;
-  background: rgba(164, 93, 65, 0.08);
-  display: grid;
-  gap: 6px;
-}
-.profile-stats span { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; }
-.profile-stats strong { font-family: 'Noto Serif', serif; font-size: 24px; color: var(--primary); }
-.activity-title { font-family: 'Noto Serif', serif; color: var(--primary); font-weight: 700; margin-bottom: 12px; }
-.activity-card ul { margin: 0; padding-left: 18px; color: var(--muted); display: grid; gap: 10px; }
 
 .resume-card {
-  max-width: 520px;
+  max-width: 560px;
   margin: 0 auto;
   border-radius: 22px;
   padding: 18px 20px;
@@ -476,61 +470,777 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   justify-content: space-between;
   gap: 16px;
 }
+
 .resume-title {
   font-weight: 800;
-  color: var(--primary-dark);
+  color: var(--primary-deep);
 }
+
 .resume-copy {
   margin-top: 4px;
   color: var(--muted);
   font-size: 13px;
 }
+
 .resume-actions {
   display: flex;
   align-items: center;
   gap: 10px;
 }
-.text-button {
-  background: transparent;
-  border: none;
-  color: var(--primary-dark);
+
+.game-layout {
+  max-width: 1460px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr) 280px;
+  gap: 18px;
+}
+
+.sidebar-panel,
+.activity-column {
+  align-self: start;
+}
+
+.sidebar-panel {
+  border-radius: 28px;
+  padding: 22px;
+}
+
+.sidebar-title,
+.activity-title {
+  margin: 10px 0 0;
+  font-family: 'Noto Serif', serif;
+  color: var(--primary-deep);
+}
+
+.timeline {
+  position: relative;
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 11px;
+  top: 10px;
+  bottom: 10px;
+  width: 1px;
+  background: rgba(140, 79, 54, 0.2);
+}
+
+.timeline-item {
+  position: relative;
+  padding-left: 28px;
+  opacity: 0.72;
+}
+
+.timeline-item.active {
+  opacity: 1;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: 6px;
+  top: 8px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(140, 79, 54, 0.22);
+}
+
+.timeline-item.active .timeline-dot {
+  background: var(--primary);
+  box-shadow: 0 0 0 6px rgba(140, 79, 54, 0.14);
+}
+
+.timeline-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: end;
+}
+
+.timeline-name {
   font-weight: 800;
+}
+
+.timeline-score {
+  font-family: 'Noto Serif', serif;
+  font-weight: 700;
+  color: var(--primary-deep);
+}
+
+.timeline-score small {
+  margin-left: 3px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.timeline-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.timeline-flag,
+.profile-tag,
+.turn-chip,
+.move-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(140, 79, 54, 0.08);
+  color: var(--primary-deep);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.timeline-flag.current,
+.turn-chip.emphasis,
+.turn-chip.bonus,
+.move-badge {
+  background: rgba(180, 141, 59, 0.15);
+}
+
+.center-column {
+  display: grid;
+  gap: 18px;
+}
+
+.team-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.team-stat,
+.phase-card,
+.turn-banner,
+.hand-shell,
+.profile-card,
+.activity-card {
+  border-radius: 24px;
+  padding: 18px;
+}
+
+.team-stat.current-team {
+  border-color: rgba(140, 79, 54, 0.28);
+}
+
+.team-stat-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.team-stat-players {
+  margin-top: 6px;
+  font-weight: 800;
+}
+
+.team-score-stack {
+  display: grid;
+  justify-items: end;
+  color: var(--primary-deep);
+}
+
+.team-score-stack strong {
+  font-family: 'Noto Serif', serif;
+  font-size: 34px;
+  line-height: 0.9;
+}
+
+.team-score-stack span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.team-progress {
+  margin-top: 14px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(140, 79, 54, 0.08);
+  overflow: hidden;
+}
+
+.team-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #c7a14a 0%, var(--primary) 100%);
+}
+
+.team-stat-line,
+.phase-name,
+.phase-turn {
+  margin-top: 10px;
+  color: var(--muted);
+}
+
+.phase-name {
+  color: var(--text);
+  font-weight: 800;
+}
+
+.turn-banner {
+  display: grid;
+  gap: 14px;
+  background: linear-gradient(180deg, rgba(255, 250, 244, 0.96) 0%, rgba(248, 238, 228, 0.94) 100%);
+}
+
+.turn-banner.is-live {
+  border-color: rgba(180, 141, 59, 0.28);
+}
+
+.turn-banner h2 {
+  margin: 6px 0 0;
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(24px, 3vw, 32px);
+  line-height: 1.08;
+  color: var(--primary-deep);
+}
+
+.turn-banner p {
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.turn-banner-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.turn-chip.warning {
+  background: rgba(122, 35, 43, 0.12);
+  color: var(--danger);
+}
+
+.turn-chip.bonus {
+  background: rgba(36, 91, 67, 0.12);
+  color: var(--good);
+}
+
+.board-shell {
+  position: relative;
+  border-radius: 36px;
+  min-height: 470px;
+  padding: 74px 26px 84px;
+  background:
+    radial-gradient(circle at 20% 14%, rgba(255, 244, 216, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(55, 94, 79, 0.95) 0%, var(--felt) 100%);
+  border: 2px solid rgba(255, 244, 216, 0.12);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 244, 216, 0.05),
+    inset 0 0 52px rgba(0, 0, 0, 0.12),
+    var(--shadow);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.board-shell::after {
+  content: '';
+  position: absolute;
+  inset: 14px;
+  border-radius: 28px;
+  border: 1px dashed var(--felt-line);
+  pointer-events: none;
+}
+
+.board-shell-armed {
+  border-color: rgba(255, 244, 216, 0.25);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 244, 216, 0.08),
+    inset 0 0 52px rgba(0, 0, 0, 0.12),
+    0 0 0 4px rgba(180, 141, 59, 0.08),
+    var(--shadow);
+}
+
+.board-hud {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  z-index: 1;
+}
+
+.hud-chip {
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: rgba(250, 242, 227, 0.96);
+  border: 1px solid rgba(255, 244, 216, 0.1);
+  font-size: 12px;
+  font-weight: 800;
+  color: #5b473a;
+}
+
+.hud-chip.accent {
+  color: var(--good);
+}
+
+.hud-chip.subdued {
+  background: rgba(250, 242, 227, 0.16);
+  color: rgba(255, 244, 216, 0.9);
+  border-color: rgba(255, 244, 216, 0.16);
+}
+
+.table-grid {
+  position: relative;
+  z-index: 1;
+  min-height: 310px;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: center;
+  gap: 22px 18px;
+  border-radius: 28px;
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+
+.table-grid.is-drop-target {
+  background: rgba(255, 244, 216, 0.08);
+  box-shadow: inset 0 0 0 2px rgba(255, 244, 216, 0.16);
+}
+
+.empty-table {
+  color: rgba(255, 244, 216, 0.84);
+  font-weight: 700;
+}
+
+.stitch-card {
+  --card-tilt: 0deg;
+  --card-lift: 0px;
+  width: 96px;
+  min-height: 142px;
+  border-radius: 18px;
+  border: 1px solid rgba(94, 61, 47, 0.16);
+  background: linear-gradient(180deg, #fffefb 0%, #fbf5ee 100%);
+  box-shadow: 0 12px 28px rgba(20, 14, 11, 0.14);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+  padding: 10px;
+  position: relative;
+  transform: translateY(var(--card-lift)) rotate(var(--card-tilt));
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease, background 140ms ease;
+}
+
+.stitch-card.is-red {
+  color: var(--primary);
+}
+
+.stitch-card.is-dark {
+  color: #26211f;
+}
+
+.card-corner {
+  font-family: 'Noto Serif', serif;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.card-corner.bottom {
+  align-self: flex-end;
+  transform: rotate(180deg);
+}
+
+.card-center {
+  display: grid;
+  place-items: center;
+  font-size: 31px;
+}
+
+.board-card.is-click-target {
+  cursor: pointer;
+}
+
+.board-card.is-highlighted {
+  --card-lift: -8px;
+  border-color: rgba(255, 244, 216, 0.4);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.18);
+}
+
+.board-card.is-target-card {
+  box-shadow: 0 0 0 3px rgba(255, 244, 216, 0.14), 0 18px 30px rgba(0, 0, 0, 0.18);
+}
+
+.board-card.is-last-played {
+  border-color: rgba(180, 141, 59, 0.45);
+}
+
+.board-card.is-direct-target {
+  box-shadow: 0 0 0 4px rgba(255, 244, 216, 0.16), 0 18px 30px rgba(0, 0, 0, 0.18);
+}
+
+.card-status-tag,
+.capture-step-tag {
+  position: absolute;
+  font-size: 10px;
+  font-weight: 800;
+  padding: 5px 8px;
+  border-radius: 999px;
+}
+
+.card-status-tag {
+  top: 8px;
+  right: 8px;
+  background: rgba(122, 35, 43, 0.14);
+  color: var(--danger);
+}
+
+.capture-step-tag {
+  bottom: 8px;
+  right: 8px;
+  min-width: 24px;
+  display: grid;
+  place-items: center;
+  background: rgba(180, 141, 59, 0.16);
+  color: var(--felt-deep);
+}
+
+.board-preview {
+  position: absolute;
+  left: 24px;
+  right: 24px;
+  bottom: 20px;
+  border-radius: 20px;
+  padding: 14px 16px;
+  z-index: 1;
+  border: 1px solid rgba(255, 244, 216, 0.12);
+  background: rgba(16, 28, 23, 0.36);
+  color: rgba(255, 248, 236, 0.96);
+  backdrop-filter: blur(6px);
+}
+
+.board-preview.trail {
+  background: rgba(16, 28, 23, 0.26);
+}
+
+.board-preview-kicker {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 244, 216, 0.78);
+}
+
+.board-preview-copy {
+  margin-top: 6px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.hand-shell {
+  display: grid;
+  gap: 14px;
+}
+
+.hand-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.hand-kicker {
+  color: rgba(140, 79, 54, 0.66);
+}
+
+.stitch-hand-row {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 4px 16px 10px;
+}
+
+.hand-card {
+  margin-left: -22px;
+  transform-origin: 50% 100%;
+}
+
+.hand-card:first-child {
+  margin-left: 0;
+}
+
+.hand-card.selected {
+  --card-lift: -12px;
+  box-shadow: 0 18px 30px rgba(20, 14, 11, 0.16);
+  border-color: rgba(140, 79, 54, 0.32);
+}
+
+.hand-card.dragging {
+  --card-lift: -20px;
+  box-shadow: 0 20px 32px rgba(20, 14, 11, 0.2);
+}
+
+.ghost-note,
+.muted-note,
+.move-label {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.move-options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 12px;
+}
+
+.move-option {
+  border: 1px solid rgba(94, 61, 47, 0.12);
+  border-radius: 20px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.76);
+  display: grid;
+  gap: 12px;
+  text-align: left;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+}
+
+.move-option.previewed,
+.move-option.drop-ready {
+  transform: translateY(-2px);
+  border-color: rgba(140, 79, 54, 0.26);
+  box-shadow: var(--shadow-soft);
+}
+
+.move-option-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.move-kicker {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.move-lineup {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.move-arrow {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.move-capture-row,
+.move-badges,
+.profile-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mini-card {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(247, 240, 229, 0.95);
+  border: 1px solid rgba(94, 61, 47, 0.08);
+  font-weight: 800;
+}
+
+.mini-card.played {
+  background: rgba(140, 79, 54, 0.08);
+}
+
+.move-empty-target {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(140, 79, 54, 0.08);
+  color: var(--primary-deep);
+  font-weight: 700;
+}
+
+.activity-column {
+  display: grid;
+  gap: 16px;
+}
+
+.profile-card {
+  text-align: center;
+}
+
+.profile-avatar {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 10px;
+  border-radius: 22px;
+  display: grid;
+  place-items: center;
+  background: rgba(140, 79, 54, 0.1);
+  color: var(--primary-deep);
+  font-size: 30px;
+  font-weight: 800;
+}
+
+.profile-name {
+  font-weight: 800;
+  font-size: 22px;
+}
+
+.profile-sub {
+  margin-top: 4px;
+  color: var(--muted);
+}
+
+.profile-stats {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.profile-stats div {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(140, 79, 54, 0.07);
+}
+
+.profile-stats span {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.profile-stats strong {
+  font-family: 'Noto Serif', serif;
+  font-size: 24px;
+  color: var(--primary-deep);
+}
+
+.activity-card ul {
+  margin: 16px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+  color: var(--muted);
+  line-height: 1.45;
 }
 
 .error-banner {
   position: fixed;
-  bottom: 14px;
   left: 50%;
+  bottom: 14px;
   transform: translateX(-50%);
-  max-width: min(900px, calc(100vw - 24px));
+  max-width: min(920px, calc(100vw - 24px));
   padding: 12px 16px;
   border-radius: 14px;
-  background: #6e1d23;
+  background: var(--danger);
   color: white;
   box-shadow: var(--shadow);
+  z-index: 40;
 }
 
-@media (max-width: 1100px) {
-  .game-layout { grid-template-columns: 1fr; }
-  .activity-column { grid-template-columns: 1fr 1fr; }
+@media (max-width: 1180px) {
+  .game-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .activity-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-@media (max-width: 760px) {
-  .topbar { padding: 0 14px; }
-  .brand-block { gap: 14px; }
-  .topnav { display: none; }
-  .topbar-actions { gap: 8px; }
-  .share-pill { display: none; }
-  .cuarenta-app { padding: 80px 12px 20px; }
-  .lobby-grid, .team-stats-row, .activity-column, .join-inline, .resume-card { grid-template-columns: 1fr; }
-  .invite-copy h1 { font-size: 46px; }
-  .board-shell { padding: 72px 14px 18px; min-height: 320px; }
+@media (max-width: 860px) {
+  .team-stats-row,
+  .activity-column,
+  .lobby-grid,
+  .join-inline,
+  .resume-card {
+    grid-template-columns: 1fr;
+  }
+
   .resume-card {
     display: grid;
     justify-items: start;
   }
+
   .resume-actions {
     width: 100%;
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    padding: 0 14px;
+  }
+
+  .brand-block {
+    gap: 12px;
+  }
+
+  .topnav {
+    display: none;
+  }
+
+  .share-pill {
+    display: none;
+  }
+
+  .cuarenta-app {
+    padding: 82px 12px 20px;
+  }
+
+  .invite-copy h1 {
+    font-size: 46px;
+  }
+
+  .board-shell {
+    padding: 86px 14px 92px;
+    min-height: 380px;
+  }
+
+  .board-preview {
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+  }
+
+  .stitch-hand-row {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding: 4px 2px 10px;
+  }
+
+  .hand-card {
+    margin-left: -12px;
+  }
+
+  .stitch-card {
+    width: 88px;
+    min-height: 132px;
+  }
+
+  .move-options-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-stats {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -120,6 +120,39 @@ button:disabled {
   gap: 10px;
 }
 
+.reconnect-dock {
+  position: relative;
+}
+
+.reconnect-summary {
+  list-style: none;
+  user-select: none;
+}
+
+.reconnect-summary::-webkit-details-marker {
+  display: none;
+}
+
+.reconnect-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(252, 247, 240, 0.98);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow);
+  z-index: 25;
+}
+
+.reconnect-title {
+  margin-top: 8px;
+  font-family: 'Noto Serif', serif;
+  font-size: 20px;
+  color: var(--primary-deep);
+}
+
 .header-button,
 .share-pill,
 .notice-card,
@@ -648,6 +681,10 @@ button:focus-visible {
   justify-content: space-between;
   gap: 10px;
   align-items: end;
+}
+
+.timeline-row.single-line {
+  justify-content: flex-start;
 }
 
 .timeline-name {
@@ -1290,6 +1327,11 @@ button:focus-visible {
   gap: 16px;
 }
 
+.order-card .activity-title,
+.recent-calls-card .activity-title {
+  margin-top: 8px;
+}
+
 .utility-card {
   display: grid;
   gap: 12px;
@@ -1317,6 +1359,20 @@ button:focus-visible {
 
 .profile-card {
   text-align: center;
+}
+
+.player-sidebar {
+  text-align: left;
+}
+
+.player-sidebar .section-kicker,
+.player-sidebar .profile-sub,
+.player-sidebar .profile-tags {
+  justify-content: flex-start;
+}
+
+.player-sidebar .profile-avatar {
+  margin: 4px 0 12px;
 }
 
 .profile-avatar {
@@ -1443,6 +1499,12 @@ button:focus-visible {
 @media (max-width: 760px) {
   .topbar {
     padding: 0 14px;
+  }
+
+  .reconnect-popover {
+    right: 0;
+    left: auto;
+    width: min(300px, calc(100vw - 24px));
   }
 
   .brand-block {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -728,6 +728,9 @@ button:focus-visible {
 }
 
 .board-shell {
+  --preview-accent: rgba(255, 244, 216, 0.16);
+  --preview-border: rgba(255, 244, 216, 0.22);
+  --preview-solid: rgba(255, 244, 216, 0.92);
   position: relative;
   border-radius: 36px;
   min-height: 470px;
@@ -750,6 +753,24 @@ button:focus-visible {
   border-radius: 28px;
   border: 1px dashed var(--felt-line);
   pointer-events: none;
+}
+
+.board-shell.preview-tone-match {
+  --preview-accent: rgba(157, 77, 57, 0.2);
+  --preview-border: rgba(216, 121, 88, 0.38);
+  --preview-solid: #f1b29d;
+}
+
+.board-shell.preview-tone-addition {
+  --preview-accent: rgba(180, 141, 59, 0.22);
+  --preview-border: rgba(227, 190, 103, 0.4);
+  --preview-solid: #f0d07d;
+}
+
+.board-shell.preview-tone-trail {
+  --preview-accent: rgba(188, 214, 203, 0.18);
+  --preview-border: rgba(221, 239, 230, 0.28);
+  --preview-solid: #ddf1e8;
 }
 
 .board-shell-armed {
@@ -807,8 +828,8 @@ button:focus-visible {
 }
 
 .table-grid.is-drop-target {
-  background: rgba(255, 244, 216, 0.08);
-  box-shadow: inset 0 0 0 2px rgba(255, 244, 216, 0.16);
+  background: var(--preview-accent);
+  box-shadow: inset 0 0 0 2px var(--preview-border);
 }
 
 .empty-table {
@@ -861,18 +882,49 @@ button:focus-visible {
   font-size: 31px;
 }
 
+.board-card {
+  appearance: none;
+  font: inherit;
+}
+
 .board-card.is-click-target {
   cursor: pointer;
 }
 
+.board-card.has-preview-target {
+  box-shadow: 0 12px 28px rgba(20, 14, 11, 0.18);
+}
+
 .board-card.is-highlighted {
   --card-lift: -8px;
-  border-color: rgba(255, 244, 216, 0.4);
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.18);
+  border-color: var(--preview-border);
+  box-shadow: 0 0 0 2px var(--preview-accent), 0 18px 30px rgba(0, 0, 0, 0.18);
 }
 
 .board-card.is-target-card {
-  box-shadow: 0 0 0 3px rgba(255, 244, 216, 0.14), 0 18px 30px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 0 4px var(--preview-border), 0 18px 30px rgba(0, 0, 0, 0.18);
+}
+
+.board-card.is-sequence-card {
+  background: linear-gradient(180deg, #fffefb 0%, #fcf7ee 100%);
+}
+
+.board-card.tone-match.is-target-card {
+  border-color: rgba(183, 88, 67, 0.8);
+}
+
+.board-card.tone-addition.is-target-card {
+  border-color: rgba(216, 173, 70, 0.9);
+}
+
+.board-card.tone-match .card-target-tag {
+  background: rgba(157, 77, 57, 0.16);
+  color: #7d2f1e;
+}
+
+.board-card.tone-addition .card-target-tag {
+  background: rgba(180, 141, 59, 0.18);
+  color: #71520d;
 }
 
 .board-card.is-last-played {
@@ -880,10 +932,11 @@ button:focus-visible {
 }
 
 .board-card.is-direct-target {
-  box-shadow: 0 0 0 4px rgba(255, 244, 216, 0.16), 0 18px 30px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 0 5px var(--preview-border), 0 18px 30px rgba(0, 0, 0, 0.18);
 }
 
 .card-status-tag,
+.card-target-tag,
 .capture-step-tag {
   position: absolute;
   font-size: 10px;
@@ -897,6 +950,12 @@ button:focus-visible {
   right: 8px;
   background: rgba(122, 35, 43, 0.14);
   color: var(--danger);
+}
+
+.card-target-tag {
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .capture-step-tag {
@@ -915,16 +974,31 @@ button:focus-visible {
   right: 24px;
   bottom: 20px;
   border-radius: 20px;
-  padding: 14px 16px;
+  padding: 16px 18px;
   z-index: 1;
-  border: 1px solid rgba(255, 244, 216, 0.12);
-  background: rgba(16, 28, 23, 0.36);
+  border: 1px solid var(--preview-border);
+  background: rgba(16, 28, 23, 0.46);
   color: rgba(255, 248, 236, 0.96);
   backdrop-filter: blur(6px);
 }
 
+.board-preview.match {
+  background: linear-gradient(180deg, rgba(60, 24, 18, 0.88) 0%, rgba(33, 17, 13, 0.74) 100%);
+}
+
+.board-preview.addition {
+  background: linear-gradient(180deg, rgba(68, 49, 16, 0.88) 0%, rgba(31, 23, 10, 0.76) 100%);
+}
+
 .board-preview.trail {
-  background: rgba(16, 28, 23, 0.26);
+  background: linear-gradient(180deg, rgba(24, 40, 33, 0.82) 0%, rgba(16, 28, 23, 0.66) 100%);
+}
+
+.board-preview-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
 }
 
 .board-preview-kicker {
@@ -939,6 +1013,76 @@ button:focus-visible {
   margin-top: 6px;
   font-weight: 700;
   line-height: 1.45;
+}
+
+.board-preview-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.preview-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 244, 216, 0.12);
+  color: rgba(255, 248, 236, 0.92);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.preview-pill.tone-match {
+  background: rgba(216, 121, 88, 0.2);
+  color: #ffe7e0;
+}
+
+.preview-pill.tone-addition {
+  background: rgba(227, 190, 103, 0.2);
+  color: #fff1cd;
+}
+
+.preview-pill.tone-trail {
+  background: rgba(221, 239, 230, 0.16);
+  color: #effbf4;
+}
+
+.preview-pill.bonus {
+  background: rgba(36, 91, 67, 0.36);
+  color: #effcf3;
+}
+
+.preview-pill.subtle {
+  background: rgba(255, 244, 216, 0.1);
+  color: rgba(255, 248, 236, 0.78);
+}
+
+.board-preview-groups {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.preview-group-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.preview-group-label {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 244, 216, 0.72);
+}
+
+.preview-group-cards {
+  font-weight: 700;
+  line-height: 1.4;
 }
 
 .hand-shell {
@@ -1006,7 +1150,19 @@ button:focus-visible {
   display: grid;
   gap: 12px;
   text-align: left;
-  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease, background 140ms ease;
+}
+
+.move-option.tone-match {
+  background: linear-gradient(180deg, rgba(255, 247, 245, 0.94) 0%, rgba(255, 252, 249, 0.86) 100%);
+}
+
+.move-option.tone-addition {
+  background: linear-gradient(180deg, rgba(255, 251, 239, 0.96) 0%, rgba(255, 254, 248, 0.88) 100%);
+}
+
+.move-option.tone-trail {
+  background: linear-gradient(180deg, rgba(246, 250, 248, 0.94) 0%, rgba(255, 255, 255, 0.84) 100%);
 }
 
 .move-option.previewed,
@@ -1021,6 +1177,18 @@ button:focus-visible {
   justify-content: space-between;
   gap: 10px;
   align-items: center;
+}
+
+.move-kind.tone-match {
+  color: #8a3a28;
+}
+
+.move-kind.tone-addition {
+  color: #8a691d;
+}
+
+.move-kind.tone-trail {
+  color: #406156;
 }
 
 .move-kicker {
@@ -1062,6 +1230,21 @@ button:focus-visible {
 
 .mini-card.played {
   background: rgba(140, 79, 54, 0.08);
+}
+
+.move-badge.tone-match {
+  background: rgba(157, 77, 57, 0.12);
+  color: #8a3a28;
+}
+
+.move-badge.tone-addition {
+  background: rgba(180, 141, 59, 0.16);
+  color: #7b5c16;
+}
+
+.move-badge.tone-trail {
+  background: rgba(188, 214, 203, 0.2);
+  color: #406156;
 }
 
 .move-empty-target {

--- a/tests/gameLogic.test.js
+++ b/tests/gameLogic.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { applyMove, getLegalMoves, rankValue, startMatchFromLobby } from '../src/lib/gameLogic.js';
+import { analyzeMove, applyMove, getDealerPlayerId, getLegalMoves, rankValue, startMatchFromLobby } from '../src/lib/gameLogic.js';
 
 function card(rank, suit, id) {
   return { id, rank, suit, value: rankValue(rank) };
@@ -97,6 +97,22 @@ test('getLegalMoves exposes separate match and addition choices and includes ful
   assert.deepEqual(addMove.captureIds, ['b2', 'b3', 'b6', 'b7']);
 });
 
+
+test('same-rank single-card addition is suppressed so hover targets stay unambiguous', () => {
+  const five = card('5', '♠', 'h5');
+  const board = [
+    card('4', '♣', 'b4'),
+    card('5', '♥', 'b5'),
+    card('6', '♦', 'b6'),
+  ];
+  const game = buildGame({ board, hostHand: [five] });
+
+  const moves = getLegalMoves(game.round, 'p1');
+
+  assert.equal(moves.filter((move) => move.type === 'match').length, 1);
+  assert.equal(moves.filter((move) => move.type === 'add').length, 0);
+});
+
 test('matching the immediately previous card counts as caída and can stack with limpia', () => {
   const five = card('5', '♠', 'h5');
   const boardCard = card('5', '♥', 'b5');
@@ -182,9 +198,38 @@ test('opening dealer is randomized among seated players', () => {
   };
 
   for (let index = 0; index < 40; index += 1) {
-    seen.add(startMatchFromLobby(game).round.dealerIndex);
+    const started = startMatchFromLobby(game);
+    seen.add(started.round.dealerIndex);
+    assert.equal(started.round.dealerPlayerId, game.seating[started.round.dealerIndex]);
+    assert.equal(getDealerPlayerId(started.round, game.seating), started.round.dealerPlayerId);
   }
 
   assert.ok(seen.size > 1, 'dealer index should not always be fixed');
   assert.ok([...seen].every((value) => value >= 0 && value < 4));
+});
+
+
+test('analyzeMove stays aligned with applied scoring bonuses', () => {
+  const five = card('5', '♠', 'h5');
+  const boardCard = card('5', '♥', 'b5');
+  const game = buildGame({
+    scoreA: 36,
+    board: [boardCard],
+    hostHand: [five],
+    lastPlayedCard: {
+      cardId: 'b5',
+      rank: '5',
+      playerId: 'p4',
+      turnNumber: 1,
+      dealNumber: 1,
+    },
+  });
+
+  const move = getLegalMoves(game.round, 'p1').find((candidate) => candidate.type === 'match');
+  const analysis = analyzeMove(game, 'p1', move);
+  const next = applyMove(game, 'p1', move);
+
+  assert.equal(analysis.bonusPoints, next.scores.A - game.scores.A);
+  assert.equal(analysis.isCaida, true);
+  assert.equal(analysis.isLimpia, true);
 });

--- a/tests/gameLogic.test.js
+++ b/tests/gameLogic.test.js
@@ -1,0 +1,190 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyMove, getLegalMoves, rankValue, startMatchFromLobby } from '../src/lib/gameLogic.js';
+
+function card(rank, suit, id) {
+  return { id, rank, suit, value: rankValue(rank) };
+}
+
+function buildGame({
+  scoreA = 0,
+  scoreB = 0,
+  activeDeal = 1,
+  playsInCurrentDeal = 1,
+  board = [],
+  hostHand = [],
+  lastPlayedCard = null,
+} = {}) {
+  const seating = ['p1', 'p2', 'p3', 'p4'];
+  const players = {
+    p1: { id: 'p1', name: 'Ana', isHost: true },
+    p2: { id: 'p2', name: 'Beto' },
+    p3: { id: 'p3', name: 'Caro' },
+    p4: { id: 'p4', name: 'Diego' },
+  };
+
+  const filler = {
+    p2: [card('Q', '♣', 'f_q')],
+    p3: [card('K', '♠', 'f_k')],
+    p4: [card('J', '♥', 'f_j')],
+  };
+
+  return {
+    status: 'playing',
+    hostId: 'p1',
+    seating,
+    players,
+    scores: { A: scoreA, B: scoreB },
+    round: {
+      handNumber: 1,
+      dealerIndex: 0,
+      turnOrder: seating,
+      turnPlayerId: 'p1',
+      activeDeal,
+      playsInCurrentDeal,
+      hands: {
+        p1: hostHand,
+        p2: filler.p2,
+        p3: filler.p3,
+        p4: filler.p4,
+      },
+      board,
+      deckRemaining: 10,
+      capturePiles: { A: [], B: [] },
+      capturedCardCount: { A: 0, B: 0 },
+      perDealHands: {
+        [activeDeal]: {
+          p1: hostHand,
+          p2: filler.p2,
+          p3: filler.p3,
+          p4: filler.p4,
+        },
+      },
+      rondaClaims: [],
+      lastPlayedCard,
+      lastCapture: null,
+      events: [],
+      teamsByPlayer: {
+        p1: { teamId: 'A', seat: 1 },
+        p2: { teamId: 'B', seat: 2 },
+        p3: { teamId: 'A', seat: 3 },
+        p4: { teamId: 'B', seat: 4 },
+      },
+      scores: { A: scoreA, B: scoreB },
+    },
+  };
+}
+
+test('getLegalMoves exposes separate match and addition choices and includes full sequence capture', () => {
+  const five = card('5', '♠', 'h5');
+  const board = [
+    card('2', '♣', 'b2'),
+    card('3', '♦', 'b3'),
+    card('5', '♥', 'b5'),
+    card('6', '♠', 'b6'),
+    card('7', '♦', 'b7'),
+  ];
+  const game = buildGame({ board, hostHand: [five] });
+
+  const moves = getLegalMoves(game.round, 'p1');
+  const matchMove = moves.find((move) => move.type === 'match');
+  const addMove = moves.find((move) => move.type === 'add');
+
+  assert.ok(matchMove, 'expected a match capture');
+  assert.ok(addMove, 'expected an addition capture');
+  assert.deepEqual(matchMove.captureIds, ['b5', 'b6', 'b7']);
+  assert.deepEqual(addMove.captureIds, ['b2', 'b3', 'b6', 'b7']);
+});
+
+test('matching the immediately previous card counts as caída and can stack with limpia', () => {
+  const five = card('5', '♠', 'h5');
+  const boardCard = card('5', '♥', 'b5');
+  const game = buildGame({
+    scoreA: 36,
+    board: [boardCard],
+    hostHand: [five],
+    lastPlayedCard: {
+      cardId: 'b5',
+      rank: '5',
+      playerId: 'p4',
+      turnNumber: 1,
+      dealNumber: 1,
+    },
+  });
+
+  const move = getLegalMoves(game.round, 'p1').find((candidate) => candidate.type === 'match');
+  const next = applyMove(game, 'p1', move);
+
+  assert.equal(next.scores.A, 40);
+  assert.match(next.round.events[0], /\(\+4\)/);
+});
+
+test('first play after a new deal does not count as caída even if the dealer card is matched', () => {
+  const five = card('5', '♠', 'h5');
+  const boardCard = card('5', '♥', 'b5');
+  const game = buildGame({
+    scoreA: 20,
+    activeDeal: 2,
+    playsInCurrentDeal: 0,
+    board: [boardCard],
+    hostHand: [five],
+    lastPlayedCard: {
+      cardId: 'b5',
+      rank: '5',
+      playerId: 'p4',
+      turnNumber: 5,
+      dealNumber: 1,
+    },
+  });
+
+  const move = getLegalMoves(game.round, 'p1').find((candidate) => candidate.type === 'match');
+  const next = applyMove(game, 'p1', move);
+
+  assert.equal(next.scores.A, 22, 'only limpia should score here');
+  assert.doesNotMatch(next.round.events[0], /\(\+4\)|ca[ií]da/i);
+});
+
+test('team at 38 does not collect limpia', () => {
+  const queen = card('Q', '♠', 'hq');
+  const boardCard = card('Q', '♦', 'bq');
+  const game = buildGame({
+    scoreA: 38,
+    board: [boardCard],
+    hostHand: [queen],
+    lastPlayedCard: null,
+  });
+
+  const move = getLegalMoves(game.round, 'p1').find((candidate) => candidate.type === 'match');
+  const next = applyMove(game, 'p1', move);
+
+  assert.equal(next.scores.A, 38);
+  assert.doesNotMatch(next.round.events[0], /\(\+2\)|limpia/i);
+});
+
+test('opening dealer is randomized among seated players', () => {
+  const seen = new Set();
+  const game = {
+    seating: ['p1', 'p2', 'p3', 'p4'],
+    players: {
+      p1: { id: 'p1', name: 'Ana', isHost: true },
+      p2: { id: 'p2', name: 'Beto' },
+      p3: { id: 'p3', name: 'Caro' },
+      p4: { id: 'p4', name: 'Diego' },
+    },
+    hostId: 'p1',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    lastActivityAt: Date.now(),
+    status: 'lobby',
+    scores: { A: 0, B: 0 },
+    lobbyMessage: 'Waiting for players',
+  };
+
+  for (let index = 0; index < 40; index += 1) {
+    seen.add(startMatchFromLobby(game).round.dealerIndex);
+  }
+
+  assert.ok(seen.size > 1, 'dealer index should not always be fixed');
+  assert.ok([...seen].every((value) => value >= 0 && value < 4));
+});


### PR DESCRIPTION
## Summary
- rework the play surface for clearer turn state, move consequences, and a more tactile felt-table presentation
- add in-app rules/scoring references plus stronger capture previews, caída surfacing, and move swing badges
- audit the high-value rule edges, randomize the opening dealer, and add focused gameplay tests

## Validation
- npm test
- npm run build
- browser sanity pass on a representative mid-hand state

## Notes
- the remembered ronda-caída +10 bonus is still intentionally not implemented
- live Firebase deploy was attempted conceptually but this machine currently has no authorized Firebase CLI account, so hosting deploy is blocked on auth rather than code readiness
