### PR TITLE
Fix RTDB auth handshake before host/join actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 import { get, onValue, ref, runTransaction } from 'firebase/database';
 import { auth, db, firebaseConfigError, firebaseMode, hasFirebase } from './lib/firebase';
+import { createRealtimeAuthProbe, waitForRealtimeAuth } from './lib/firebaseReady';
 import { getSavedName, saveName } from './lib/localPlayer';
 import { analyzeMove, applyMove, createInitialGameState, generateGameCode, getDealerPlayerId, getLegalMoves, getVisibleHand, startMatchFromLobby, teamSummary } from './lib/gameLogic';
 import { buildGameUrl, clearSavedSession, getGameCodeFromUrl, getSavedSession, isValidGameCode, normalizeGameCode, saveGameSession, syncGameUrl } from './lib/session';
@@ -732,6 +733,10 @@ export default function App() {
   }));
 
   const playerId = authState.playerId;
+  const realtimeAuthProbe = useMemo(
+    () => (db ? createRealtimeAuthProbe(db) : null),
+    [db]
+  );
   const canUseRealtime = hasFirebase && authState.status === 'ready';
   const gameRef = useMemo(
     () => (gameCode && canUseRealtime ? ref(db, `games/${gameCode}`) : null),
@@ -790,6 +795,7 @@ export default function App() {
 
     let active = true;
     let signInPromise = null;
+    let authSyncAttempt = 0;
 
     const unsubscribe = onAuthStateChanged(
       auth,
@@ -797,7 +803,20 @@ export default function App() {
         if (!active) return;
 
         if (user) {
-          setAuthState({ status: 'ready', playerId: user.uid, error: '' });
+          const attemptId = ++authSyncAttempt;
+          setAuthState({ status: 'authorizing-db', playerId: '', error: '' });
+          try {
+            await waitForRealtimeAuth({ user, probe: realtimeAuthProbe });
+            if (!active || attemptId !== authSyncAttempt) return;
+            setAuthState({ status: 'ready', playerId: user.uid, error: '' });
+          } catch (authError) {
+            if (!active || attemptId !== authSyncAttempt) return;
+            setAuthState({
+              status: 'error',
+              playerId: '',
+              error: authError.message || 'Anonymous sign-in failed.',
+            });
+          }
           return;
         }
 
@@ -832,7 +851,7 @@ export default function App() {
       active = false;
       unsubscribe();
     };
-  }, []);
+  }, [realtimeAuthProbe]);
 
   useEffect(() => {
     syncGameUrl(gameCode);
@@ -1164,13 +1183,13 @@ export default function App() {
 
       {authPending ? (
         <section className="notice-card">
-          Signing this browser into Firebase anonymously… no email, password, or profile setup required.
+          Preparing the anonymous Firebase session for this browser… one short auth/database handshake and then you can host or join.
         </section>
       ) : null}
 
       {authFailed ? (
         <section className="notice-card">
-          Anonymous Firebase sign-in failed. {authState.error || 'Enable Anonymous Auth for the project or start the Auth emulator for local work.'}
+          Firebase session setup failed. {authState.error || 'Enable Anonymous Auth for the project or start the Auth emulator for local work.'}
         </section>
       ) : null}
 

--- a/src/lib/firebaseReady.js
+++ b/src/lib/firebaseReady.js
@@ -1,6 +1,6 @@
 import { get, ref } from 'firebase/database';
 
-export const AUTH_PROBE_GAME_CODE = 'AAAAAA';
+export const AUTH_PROBE_GAME_CODE = '__auth_probe__';
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lib/firebaseReady.js
+++ b/src/lib/firebaseReady.js
@@ -1,0 +1,58 @@
+import { get, ref } from 'firebase/database';
+
+export const AUTH_PROBE_GAME_CODE = 'AAAAAA';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isPermissionDenied(error) {
+  const code = String(error?.code || '').toLowerCase();
+  const message = String(error?.message || '').toLowerCase();
+  return code.includes('permission') || message.includes('permission_denied') || message.includes('permission denied');
+}
+
+export function createRealtimeAuthProbe(db, probeCode = AUTH_PROBE_GAME_CODE) {
+  return () => get(ref(db, `games/${probeCode}`));
+}
+
+export async function waitForRealtimeAuth({
+  user,
+  probe,
+  maxAttempts = 6,
+  delayMs = 250,
+} = {}) {
+  if (!user || typeof user.getIdToken !== 'function') {
+    throw new Error('Anonymous Firebase session is not ready yet.');
+  }
+
+  if (typeof probe !== 'function') {
+    throw new Error('Realtime Database auth probe is not configured.');
+  }
+
+  await user.getIdToken();
+
+  let lastError = null;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      await probe();
+      return;
+    } catch (error) {
+      if (!isPermissionDenied(error)) throw error;
+      lastError = error;
+      if (attempt >= maxAttempts - 1) break;
+      if (attempt === 0) {
+        try {
+          await user.getIdToken(true);
+        } catch {
+          // Ignore token-refresh failures here and let the next probe surface the real issue.
+        }
+      }
+      await sleep(delayMs);
+    }
+  }
+
+  const error = new Error('Firebase auth finished, but the Realtime Database session did not catch up yet. Please retry in a second.');
+  error.cause = lastError;
+  throw error;
+}

--- a/tests/firebaseReady.test.js
+++ b/tests/firebaseReady.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isPermissionDenied, waitForRealtimeAuth } from '../src/lib/firebaseReady.js';
+
+test('isPermissionDenied catches Firebase permission-denied variants', () => {
+  assert.equal(isPermissionDenied({ code: 'PERMISSION_DENIED' }), true);
+  assert.equal(isPermissionDenied({ message: 'transaction failed: permission_denied' }), true);
+  assert.equal(isPermissionDenied({ code: 'auth/network-request-failed' }), false);
+});
+
+test('waitForRealtimeAuth resolves once the probe succeeds after a transient permission denial', async () => {
+  const tokenCalls = [];
+  const user = {
+    async getIdToken(forceRefresh = false) {
+      tokenCalls.push(forceRefresh);
+      return 'token';
+    },
+  };
+
+  let attempts = 0;
+  await waitForRealtimeAuth({
+    user,
+    delayMs: 0,
+    probe: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        const error = new Error('permission_denied');
+        error.code = 'PERMISSION_DENIED';
+        throw error;
+      }
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(tokenCalls, [false, true]);
+});
+
+test('waitForRealtimeAuth rethrows non-permission failures immediately', async () => {
+  const user = {
+    async getIdToken() {
+      return 'token';
+    },
+  };
+
+  const boom = new Error('backend offline');
+  await assert.rejects(
+    waitForRealtimeAuth({
+      user,
+      delayMs: 0,
+      probe: async () => {
+        throw boom;
+      },
+    }),
+    boom
+  );
+});
+
+test('waitForRealtimeAuth surfaces a friendly error after repeated permission denials', async () => {
+  const user = {
+    async getIdToken() {
+      return 'token';
+    },
+  };
+
+  await assert.rejects(
+    waitForRealtimeAuth({
+      user,
+      maxAttempts: 2,
+      delayMs: 0,
+      probe: async () => {
+        const error = new Error('transaction failed: permission_denied');
+        error.code = 'PERMISSION_DENIED';
+        throw error;
+      },
+    }),
+    /Realtime Database session did not catch up yet/
+  );
+});


### PR DESCRIPTION
## Summary
- wait for the Firebase Auth -> Realtime Database handshake before enabling host/join actions
- add a lightweight RTDB auth probe with bounded retry logic for transient `permission_denied` races
- add focused tests for the new handshake helper

## Root cause
The live database rules still allow authenticated game creation. I verified that with a direct live Firebase probe. The failure path is the browser UI marking auth as "ready" slightly before Realtime Database has fully attached the anonymous auth session, so the first transaction can hit `permission_denied` even though Auth itself has already resolved.

## Validation
- `npm test`
- `npm run build`

## Notes
This is intentionally a narrow fix. It keeps the stricter rules in place and fixes the client-side readiness gate instead of loosening database access.
